### PR TITLE
rnn: fix 'radix' attr

### DIFF
--- a/rnn/rnn.c
+++ b/rnn/rnn.c
@@ -186,6 +186,7 @@ static int trytypeattr (struct rnndb *db, char *file, xmlNode *node, xmlAttr *at
 	} else if (!strcmp(attr->name, "radix")) {
 		ti->radix = getnumattrib(db, file, node->line, attr);
 		ti->radixvalid = 1;
+		return 1;
 	}
 	return 0;
 }


### PR DESCRIPTION
Return 1 so that it is treated as a valid attribute.
