### PR TITLE
rnndb: add entire gk20a register set

### DIFF
--- a/rnndb/gk20a/gk20a_bus.xml
+++ b/rnndb/gk20a/gk20a_bus.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database  xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_PBUS">
+        <reg32 offset="0x1704" name="BAR1_BLOCK" variants="GK20A">
+            <bitfield low="0" high="27" name="PTR" scope="NV_PBUS_BAR1_BLOCK"/>
+            <bitfield low="28" high="29" name="TARGET" scope="NV_PBUS_BAR1_BLOCK">
+                <enum name="TARGET_VID_MEM" value="0"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="MODE" scope="NV_PBUS_BAR1_BLOCK">
+                <enum name="MODE_VIRTUAL" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x1714" name="BAR2_BLOCK" variants="GK20A">
+            <bitfield low="0" high="27" name="PTR" scope="NV_PBUS_BAR2_BLOCK"/>
+            <bitfield low="28" high="29" name="TARGET" scope="NV_PBUS_BAR2_BLOCK">
+                <enum name="TARGET_VID_MEM" value="0"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="MODE" scope="NV_PBUS_BAR2_BLOCK">
+                <enum name="MODE_VIRTUAL" value="1"/>
+            </bitfield>
+        </reg32>
+        <enum name="NV_PBAR1_BLOCK_PTR_SHIFT" value="12"/>
+        <enum name="NV_PBAR2_BLOCK_PTR_SHIFT" value="12"/>
+        <reg32 offset="0x1100" name="INTR_0" variants="GK20A">
+            <bitfield low="1" high="1" name="PRI_SQUASH" scope="NV_PBUS_INTR_0"/>
+            <bitfield low="2" high="2" name="PRI_FECSERR" scope="NV_PBUS_INTR_0"/>
+            <bitfield low="3" high="3" name="PRI_TIMEOUT" scope="NV_PBUS_INTR_0"/>
+        </reg32>
+        <reg32 offset="0x1140" name="INTR_EN_0" variants="GK20A">
+            <bitfield low="1" high="1" name="PRI_SQUASH" scope="NV_PBUS_INTR_EN_0"/>
+            <bitfield low="2" high="2" name="PRI_FECSERR" scope="NV_PBUS_INTR_EN_0"/>
+            <bitfield low="3" high="3" name="PRI_TIMEOUT" scope="NV_PBUS_INTR_EN_0"/>
+        </reg32>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_ccsr.xml
+++ b/rnndb/gk20a/gk20a_ccsr.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_PCCSR">
+        <reg32 offset="0x800000" name="CHANNEL_INST" variants="GK20A">
+            <enum name="_SIZE_1" value="128"/>
+            <bitfield low="0" high="27" name="PTR" scope="NV_PCCSR_CHANNEL_INST"/>
+            <bitfield low="28" high="29" name="TARGET" scope="NV_PCCSR_CHANNEL_INST">
+                <enum name="TARGET_VID_MEM" value="0"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="BIND" scope="NV_PCCSR_CHANNEL_INST">
+                <enum name="BIND_FALSE" value="0"/>
+                <enum name="BIND_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x800004" name="CHANNEL" variants="GK20A">
+            <enum name="_SIZE_1" value="128"/>
+            <bitfield low="0" high="0" name="ENABLE" scope="NV_PCCSR_CHANNEL"/>
+            <bitfield low="10" high="10" name="ENABLE_SET" scope="NV_PCCSR_CHANNEL">
+                <enum name="ENABLE_SET_TRUE" value="1"/>
+            </bitfield>
+            <bitfield low="11" high="11" name="ENABLE_CLR" scope="NV_PCCSR_CHANNEL">
+                <enum name="ENABLE_CLR_TRUE" value="1"/>
+            </bitfield>
+            <bitfield low="16" high="19" name="RUNLIST" scope="NV_PCCSR_CHANNEL"/>
+            <bitfield low="24" high="27" name="STATUS" scope="NV_PCCSR_CHANNEL"/>
+            <bitfield low="28" high="28" name="BUSY" scope="NV_PCCSR_CHANNEL"/>
+        </reg32>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_ce2.xml
+++ b/rnndb/gk20a/gk20a_ce2.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_PCE2">
+        <reg32 offset="0x106908" name="COP2_INTR_STATUS" variants="GK20A">
+            <bitfield low="0" high="0" name="BLOCKPIPE" scope="NV_PCE2_COP2_INTR_STATUS">
+                <enum name="BLOCKPIPE_PENDING" value="1"/>
+                <enum name="BLOCKPIPE_RESET" value="1"/>
+            </bitfield>
+            <bitfield low="1" high="1" name="NONBLOCKPIPE" scope="NV_PCE2_COP2_INTR_STATUS">
+                <enum name="NONBLOCKPIPE_PENDING" value="1"/>
+                <enum name="NONBLOCKPIPE_RESET" value="1"/>
+            </bitfield>
+            <bitfield low="2" high="2" name="LAUNCHERR" scope="NV_PCE2_COP2_INTR_STATUS">
+                <enum name="LAUNCHERR_PENDING" value="1"/>
+                <enum name="LAUNCHERR_RESET" value="1"/>
+            </bitfield>
+        </reg32>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_ctxsw.xml
+++ b/rnndb/gk20a/gk20a_ctxsw.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_CTXSW">
+        <enum name="NV_FECS_HEADER" value="256"/>
+        <reg32 offset="0x8" name="MAIN_IMAGE_NUM_GPCS" variants="GK20A"/>
+        <reg32 offset="0x10" name="MAIN_IMAGE_PRI_PATCH_COUNT" variants="GK20A"/>
+        <reg32 offset="0x14" name="MAIN_IMAGE_PRI_PATCH_ADR_LO" variants="GK20A"/>
+        <reg32 offset="0x18" name="MAIN_IMAGE_PRI_PATCH_ADR_HI" variants="GK20A"/>
+        <reg32 offset="0x1c" name="MAIN_IMAGE_ZCULL" variants="GK20A">
+            <bitfield low="0" high="2" name="MODE" scope="NV_CTXSW_MAIN_IMAGE_ZCULL">
+                <enum name="MODE_NO_CTXSW" value="1"/>
+                <enum name="MODE_SEPARATE_BUFFER" value="2"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x20" name="MAIN_IMAGE_ZCULL_PTR" variants="GK20A"/>
+        <reg32 offset="0x28" name="MAIN_IMAGE_PM" variants="GK20A">
+            <bitfield low="0" high="2" name="MODE" scope="NV_CTXSW_MAIN_IMAGE_PM">
+                <enum name="MODE_NO_CTXSW" value="0"/>
+            </bitfield>
+            <bitfield low="3" high="5" name="NV_CTXSW_MAIN_IMAGE_SMPC_MODE" scope="NV_CTXSW_MAIN_IMAGE_PM">
+                <enum name="NV_CTXSW_MAIN_IMAGE_SMPC_MODE_CTXSW" value="1"/>
+                <enum name="NV_CTXSW_MAIN_IMAGE_SMPC_MODE_NO_CTXSW" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x2c" name="MAIN_IMAGE_PM_PTR" variants="GK20A"/>
+        <reg32 offset="0xf4" name="MAIN_IMAGE_NUM_SAVE_OPERATIONS" variants="GK20A"/>
+        <reg32 offset="0xf8" name="MAIN_IMAGE_NUM_RESTORE_OPERATIONS" variants="GK20A"/>
+        <reg32 offset="0xfc" name="MAIN_IMAGE_MAGIC_VALUE" variants="GK20A">
+            <bitfield low="0" high="31" name="V" scope="NV_CTXSW_MAIN_IMAGE_MAGIC_VALUE">
+                <enum name="V_VALUE" value="1611514078"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0xc" name="LOCAL_PRIV_REGISTER_CTL" variants="GK20A">
+            <bitfield low="0" high="15" name="OFFSET" scope="NV_CTXSW_LOCAL_PRIV_REGISTER_CTL"/>
+        </reg32>
+        <reg32 offset="0xf4" name="LOCAL_IMAGE_PPC_INFO" variants="GK20A">
+            <bitfield low="0" high="15" name="NUM_PPCS" scope="NV_CTXSW_LOCAL_IMAGE_PPC_INFO"/>
+            <bitfield low="16" high="31" name="PPC_MASK" scope="NV_CTXSW_LOCAL_IMAGE_PPC_INFO"/>
+        </reg32>
+        <reg32 offset="0xf8" name="LOCAL_IMAGE_NUM_TPCS" variants="GK20A"/>
+        <reg32 offset="0xfc" name="LOCAL_MAGIC_VALUE" variants="GK20A">
+            <bitfield low="0" high="31" name="V" scope="NV_CTXSW_LOCAL_MAGIC_VALUE">
+                <enum name="V_VALUE" value="2903239851"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0xec" name="MAIN_EXTENDED_BUFFER_CTL" variants="GK20A">
+            <bitfield low="0" high="15" name="OFFSET" scope="NV_CTXSW_MAIN_EXTENDED_BUFFER_CTL"/>
+            <bitfield low="16" high="23" name="SIZE" scope="NV_CTXSW_MAIN_EXTENDED_BUFFER_CTL"/>
+        </reg32>
+        <enum name="NV_EXTENDED_BUFFER_SEGMENTS_SIZE_IN_BYTES" value="256"/>
+        <enum name="NV_EXTENDED_MARKER_SIZE_IN_BYTES" value="4"/>
+        <enum name="NV_EXTENDED_SM_DSM_PERF_COUNTER_REGISTER_STRIDE" value="5"/>
+        <enum name="NV_EXTENDED_SM_DSM_PERF_COUNTER_CONTROL_REGISTER_STRIDE" value="4"/>
+        <enum name="NV_EXTENDED_NUM_SMPC_QUADRANTS" value="4"/>
+        <reg32 offset="0xa0" name="MAIN_IMAGE_PRIV_ACCESS_MAP_CONFIG" variants="GK20A">
+            <bitfield low="0" high="1" name="MODE" scope="NV_CTXSW_MAIN_IMAGE_PRIV_ACCESS_MAP_CONFIG">
+                <enum name="MODE_ALLOW_ALL" value="0"/>
+                <enum name="MODE_USE_MAP" value="2"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0xa4" name="MAIN_IMAGE_PRIV_ACCESS_MAP_ADDR_LO" variants="GK20A"/>
+        <reg32 offset="0xa8" name="MAIN_IMAGE_PRIV_ACCESS_MAP_ADDR_HI" variants="GK20A"/>
+        <reg32 offset="0x3c" name="MAIN_IMAGE_MISC_OPTIONS" variants="GK20A">
+            <bitfield low="3" high="3" name="VERIF_FEATURES" scope="NV_CTXSW_MAIN_IMAGE_MISC_OPTIONS">
+                <enum name="VERIF_FEATURES_DISABLED" value="0"/>
+            </bitfield>
+        </reg32>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_fb.xml
+++ b/rnndb/gk20a/gk20a_fb.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_PFB">
+        <reg32 offset="0x100c80" name="PRI_MMU_CTRL" variants="GK20A">
+            <bitfield low="0" high="0" name="VM_PG_SIZE" scope="NV_PFB_PRI_MMU_CTRL">
+                <enum name="VM_PG_SIZE_128KB" value="0"/>
+                <enum name="VM_PG_SIZE_64KB" value="1"/>
+            </bitfield>
+            <bitfield low="15" high="15" name="PRI_FIFO_EMPTY" scope="NV_PFB_PRI_MMU_CTRL">
+                <enum name="PRI_FIFO_EMPTY_FALSE" value="0"/>
+            </bitfield>
+            <bitfield low="16" high="23" name="PRI_FIFO_SPACE" scope="NV_PFB_PRI_MMU_CTRL"/>
+        </reg32>
+        <reg32 offset="0x100cb8" name="PRI_MMU_INVALIDATE_PDB" variants="GK20A">
+            <bitfield low="1" high="1" name="APERTURE" scope="NV_PFB_PRI_MMU_INVALIDATE_PDB">
+                <enum name="APERTURE_VID_MEM" value="0"/>
+            </bitfield>
+            <bitfield low="4" high="31" name="ADDR" scope="NV_PFB_PRI_MMU_INVALIDATE_PDB"/>
+        </reg32>
+        <reg32 offset="0x100cbc" name="PRI_MMU_INVALIDATE" variants="GK20A">
+            <bitfield low="0" high="0" name="ALL_VA" scope="NV_PFB_PRI_MMU_INVALIDATE">
+                <enum name="ALL_VA_TRUE" value="1"/>
+            </bitfield>
+            <bitfield low="1" high="1" name="ALL_PDB" scope="NV_PFB_PRI_MMU_INVALIDATE">
+                <enum name="ALL_PDB_TRUE" value="1"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="TRIGGER" scope="NV_PFB_PRI_MMU_INVALIDATE">
+                <enum name="TRIGGER_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x100cc8" name="PRI_MMU_DEBUG_WR" variants="GK20A">
+            <bitfield low="0" high="1" name="APERTURE" scope="NV_PFB_PRI_MMU_DEBUG_WR">
+                <enum name="APERTURE_VID_MEM" value="0"/>
+            </bitfield>
+            <bitfield low="2" high="2" name="VOL" scope="NV_PFB_PRI_MMU_DEBUG_WR">
+                <enum name="VOL_FALSE" value="0"/>
+                <enum name="VOL_TRUE" value="1"/>
+            </bitfield>
+            <bitfield low="4" high="31" name="ADDR" scope="NV_PFB_PRI_MMU_DEBUG_WR">
+                <enum name="ADDR_ALIGNMENT" value="12"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x100ccc" name="PRI_MMU_DEBUG_RD" variants="GK20A">
+            <bitfield low="0" high="1" name="APERTURE" scope="NV_PFB_PRI_MMU_DEBUG_RD">
+                <enum name="APERTURE_VID_MEM" value="0"/>
+            </bitfield>
+            <bitfield low="2" high="2" name="VOL" scope="NV_PFB_PRI_MMU_DEBUG_RD">
+                <enum name="VOL_FALSE" value="0"/>
+            </bitfield>
+            <bitfield low="4" high="31" name="ADDR" scope="NV_PFB_PRI_MMU_DEBUG_RD">
+                <enum name="ADDR_ALIGNMENT" value="12"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x100cc4" name="PRI_MMU_DEBUG_CTRL" variants="GK20A">
+            <bitfield low="16" high="16" name="DEBUG" scope="NV_PFB_PRI_MMU_DEBUG_CTRL">
+                <enum name="DEBUG_ENABLED" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x100cd0" name="PRI_MMU_VPR_INFO" variants="GK20A">
+            <bitfield low="2" high="2" name="FETCH" scope="NV_PFB_PRI_MMU_VPR_INFO">
+                <enum name="FETCH_FALSE" value="0"/>
+                <enum name="FETCH_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_fifo.xml
+++ b/rnndb/gk20a/gk20a_fifo.xml
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_PFIFO">
+        <reg32 offset="0x2254" name="BAR1_BASE" variants="GK20A">
+            <bitfield low="0" high="27" name="PTR" scope="NV_PFIFO_BAR1_BASE">
+                <enum name="PTR_ALIGN_SHIFT" value="12"/>
+            </bitfield>
+            <bitfield low="28" high="28" name="VALID" scope="NV_PFIFO_BAR1_BASE">
+                <enum name="VALID_FALSE" value="0"/>
+                <enum name="VALID_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x2270" name="RUNLIST_BASE" variants="GK20A">
+            <bitfield low="0" high="27" name="PTR" scope="NV_PFIFO_RUNLIST_BASE"/>
+            <bitfield low="28" high="29" name="TARGET" scope="NV_PFIFO_RUNLIST_BASE">
+                <enum name="TARGET_VID_MEM" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x2274" name="RUNLIST" variants="GK20A">
+            <bitfield low="20" high="23" name="ID" scope="NV_PFIFO_RUNLIST"/>
+        </reg32>
+        <reg32 offset="0x2280" name="ENG_RUNLIST_BASE" variants="GK20A">
+            <enum name="_SIZE_1" value="1"/>
+        </reg32>
+        <reg32 offset="0x2284" name="ENG_RUNLIST" variants="GK20A">
+            <enum name="_SIZE_1" value="1"/>
+            <bitfield low="0" high="15" name="LENGTH" scope="NV_PFIFO_ENG_RUNLIST"/>
+            <bitfield low="20" high="20" name="PENDING" scope="NV_PFIFO_ENG_RUNLIST">
+                <enum name="PENDING_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x2310" name="RUNLIST_TIMESLICE" variants="GK20A">
+            <bitfield low="0" high="7" name="TIMEOUT" scope="NV_PFIFO_RUNLIST_TIMESLICE">
+                <enum name="TIMEOUT_128" value="128"/>
+            </bitfield>
+            <bitfield low="12" high="15" name="TIMESCALE" scope="NV_PFIFO_RUNLIST_TIMESLICE">
+                <enum name="TIMESCALE_3" value="3"/>
+            </bitfield>
+            <bitfield low="28" high="28" name="ENABLE" scope="NV_PFIFO_RUNLIST_TIMESLICE">
+                <enum name="ENABLE_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x2a0c" name="ENG_TIMEOUT" variants="GK20A">
+            <bitfield low="0" high="30" name="PERIOD" scope="NV_PFIFO_ENG_TIMEOUT">
+                <enum name="PERIOD_MAX" value="2147483647"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="DETECTION" scope="NV_PFIFO_ENG_TIMEOUT">
+                <enum name="DETECTION_ENABLED" value="1"/>
+                <enum name="DETECTION_DISABLED" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x2350" name="PB_TIMESLICE" variants="GK20A">
+            <bitfield low="0" high="7" name="TIMEOUT" scope="NV_PFIFO_PB_TIMESLICE">
+                <enum name="TIMEOUT_16" value="16"/>
+            </bitfield>
+            <bitfield low="12" high="15" name="TIMESCALE" scope="NV_PFIFO_PB_TIMESLICE">
+                <enum name="TIMESCALE_0" value="0"/>
+            </bitfield>
+            <bitfield low="28" high="28" name="ENABLE" scope="NV_PFIFO_PB_TIMESLICE">
+                <enum name="ENABLE_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x2390" name="PBDMA_MAP" variants="GK20A"/>
+        <reg32 offset="0x2100" name="INTR_0" variants="GK20A">
+            <bitfield low="0" high="0" name="BIND_ERROR" scope="NV_PFIFO_INTR_0">
+                <enum name="BIND_ERROR_PENDING" value="1"/>
+                <enum name="BIND_ERROR_RESET" value="1"/>
+            </bitfield>
+            <bitfield low="4" high="4" name="PIO_ERROR" scope="NV_PFIFO_INTR_0">
+                <enum name="PIO_ERROR_PENDING" value="1"/>
+                <enum name="PIO_ERROR_RESET" value="1"/>
+            </bitfield>
+            <bitfield low="8" high="8" name="SCHED_ERROR" scope="NV_PFIFO_INTR_0">
+                <enum name="SCHED_ERROR_PENDING" value="1"/>
+                <enum name="SCHED_ERROR_RESET" value="1"/>
+            </bitfield>
+            <bitfield low="16" high="16" name="CHSW_ERROR" scope="NV_PFIFO_INTR_0">
+                <enum name="CHSW_ERROR_PENDING" value="1"/>
+                <enum name="CHSW_ERROR_RESET" value="1"/>
+            </bitfield>
+            <bitfield low="23" high="23" name="FB_FLUSH_TIMEOUT" scope="NV_PFIFO_INTR_0">
+                <enum name="FB_FLUSH_TIMEOUT_PENDING" value="1"/>
+                <enum name="FB_FLUSH_TIMEOUT_RESET" value="1"/>
+            </bitfield>
+            <bitfield low="24" high="24" name="LB_ERROR" scope="NV_PFIFO_INTR_0">
+                <enum name="LB_ERROR_PENDING" value="1"/>
+                <enum name="LB_ERROR_RESET" value="1"/>
+            </bitfield>
+            <bitfield low="27" high="27" name="DROPPED_MMU_FAULT" scope="NV_PFIFO_INTR_0">
+                <enum name="DROPPED_MMU_FAULT_PENDING" value="1"/>
+                <enum name="DROPPED_MMU_FAULT_RESET" value="1"/>
+            </bitfield>
+            <bitfield low="28" high="28" name="MMU_FAULT" scope="NV_PFIFO_INTR_0">
+                <enum name="MMU_FAULT_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="29" high="29" name="PBDMA_INTR" scope="NV_PFIFO_INTR_0">
+                <enum name="PBDMA_INTR_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="30" high="30" name="RUNLIST_EVENT" scope="NV_PFIFO_INTR_0">
+                <enum name="RUNLIST_EVENT_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="CHANNEL_INTR" scope="NV_PFIFO_INTR_0">
+                <enum name="CHANNEL_INTR_PENDING" value="1"/>
+                <enum name="CHANNEL_INTR_RESET" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x2140" name="INTR_EN_0" variants="GK20A">
+            <bitfield low="8" high="8" name="SCHED_ERROR" scope="NV_PFIFO_INTR_EN_0"/>
+        </reg32>
+        <reg32 offset="0x2528" name="INTR_EN_1" variants="GK20A"/>
+        <reg32 offset="0x252c" name="INTR_BIND_ERROR" variants="GK20A"/>
+        <reg32 offset="0x254c" name="INTR_SCHED_ERROR" variants="GK20A">
+            <bitfield low="0" high="7" name="CODE" scope="NV_PFIFO_INTR_SCHED_ERROR">
+                <enum name="CODE_CTXSW_TIMEOUT" value="10"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x256c" name="INTR_CHSW_ERROR" variants="GK20A"/>
+        <reg32 offset="0x259c" name="INTR_MMU_FAULT_ID" variants="GK20A"/>
+        <enum name="NV_PINTR_MMU_FAULT_ENG_ID_GRAPHICS" value="0"/>
+        <reg32 offset="0x2800" name="INTR_MMU_FAULT_INST" variants="GK20A">
+            <bitfield low="0" high="27" name="PTR" scope="NV_PFIFO_INTR_MMU_FAULT_INST"/>
+        </reg32>
+        <enum name="NV_PINTR_MMU_FAULT_INST_PTR_ALIGN_SHIFT" value="12"/>
+        <reg32 offset="0x2804" name="INTR_MMU_FAULT_LO" variants="GK20A"/>
+        <reg32 offset="0x2808" name="INTR_MMU_FAULT_HI" variants="GK20A"/>
+        <reg32 offset="0x280c" name="INTR_MMU_FAULT_INFO" variants="GK20A">
+            <bitfield low="0" high="3" name="TYPE" scope="NV_PFIFO_INTR_MMU_FAULT_INFO"/>
+            <bitfield low="6" high="6" name="ENGINE_SUBID" scope="NV_PFIFO_INTR_MMU_FAULT_INFO">
+                <enum name="ENGINE_SUBID_GPC" value="0"/>
+                <enum name="ENGINE_SUBID_HUB" value="1"/>
+            </bitfield>
+            <bitfield low="8" high="12" name="CLIENT" scope="NV_PFIFO_INTR_MMU_FAULT_INFO"/>
+        </reg32>
+        <reg32 offset="0x25a0" name="INTR_PBDMA_ID" variants="GK20A">
+            <bitfield low="0" high="0" name="STATUS" scope="NV_PFIFO_INTR_PBDMA_ID">
+                <enum name="STATUS__SIZE_1" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x2a00" name="INTR_RUNLIST" variants="GK20A"/>
+        <reg32 offset="0x2a04" name="FB_TIMEOUT" variants="GK20A">
+            <bitfield low="0" high="29" name="PERIOD" scope="NV_PFIFO_FB_TIMEOUT">
+                <enum name="PERIOD_MAX" value="1073741823"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x2a08" name="PB_TIMEOUT" variants="GK20A">
+            <bitfield low="31" high="31" name="DETECTION" scope="NV_PFIFO_PB_TIMEOUT">
+                <enum name="DETECTION_ENABLED" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x262c" name="ERROR_SCHED_DISABLE" variants="GK20A"/>
+        <reg32 offset="0x2630" name="SCHED_DISABLE" variants="GK20A">
+            <bitfield low="0" high="0" name="RUNLIST" scope="NV_PFIFO_SCHED_DISABLE"/>
+        </reg32>
+        <enum name="NV_PSCHED_DISABLE_TRUE" value="1"/>
+        <reg32 offset="0x2634" name="PREEMPT" variants="GK20A">
+            <bitfield low="20" high="20" name="PENDING" scope="NV_PFIFO_PREEMPT">
+                <enum name="PENDING_TRUE" value="1"/>
+            </bitfield>
+            <bitfield low="24" high="25" name="TYPE" scope="NV_PFIFO_PREEMPT">
+                <enum name="TYPE_CHANNEL" value="0"/>
+                <enum name="TYPE_TSG" value="1"/>
+            </bitfield>
+            <bitfield low="0" high="11" name="ID" scope="NV_PFIFO_PREEMPT"/>
+            <bitfield low="0" high="11" name="ID" scope="NV_PFIFO_PREEMPT"/>
+        </reg32>
+        <reg32 offset="0x2a30" name="TRIGGER_MMU_FAULT" variants="GK20A">
+            <bitfield low="0" high="4" name="ID" scope="NV_PFIFO_TRIGGER_MMU_FAULT"/>
+            <bitfield low="8" high="8" name="ENABLE" scope="NV_PFIFO_TRIGGER_MMU_FAULT"/>
+        </reg32>
+        <reg32 offset="0x2640" name="ENGINE_STATUS" variants="GK20A">
+            <enum name="_SIZE_1" value="2"/>
+            <bitfield low="0" high="11" name="ID" scope="NV_PFIFO_ENGINE_STATUS"/>
+            <bitfield low="12" high="12" name="ID_TYPE" scope="NV_PFIFO_ENGINE_STATUS">
+                <enum name="ID_TYPE_CHID" value="0"/>
+                <enum name="ID_TYPE_TSGID" value="1"/>
+            </bitfield>
+            <bitfield low="13" high="15" name="CTX_STATUS" scope="NV_PFIFO_ENGINE_STATUS">
+                <enum name="CTX_STATUS_VALID" value="1"/>
+                <enum name="CTX_STATUS_CTXSW_LOAD" value="5"/>
+                <enum name="CTX_STATUS_CTXSW_SAVE" value="6"/>
+                <enum name="CTX_STATUS_CTXSW_SWITCH" value="7"/>
+            </bitfield>
+            <bitfield low="16" high="27" name="NEXT_ID" scope="NV_PFIFO_ENGINE_STATUS"/>
+            <bitfield low="28" high="28" name="NEXT_ID_TYPE" scope="NV_PFIFO_ENGINE_STATUS">
+                <enum name="NEXT_ID_TYPE_CHID" value="0"/>
+            </bitfield>
+            <bitfield low="30" high="30" name="FAULTED" scope="NV_PFIFO_ENGINE_STATUS">
+                <enum name="FAULTED_TRUE" value="1"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="ENGINE" scope="NV_PFIFO_ENGINE_STATUS">
+                <enum name="ENGINE_IDLE" value="0"/>
+                <enum name="ENGINE_BUSY" value="1"/>
+            </bitfield>
+            <bitfield low="15" high="15" name="CTXSW" scope="NV_PFIFO_ENGINE_STATUS">
+                <enum name="CTXSW_IN_PROGRESS" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x3080" name="PBDMA_STATUS" variants="GK20A">
+            <enum name="_SIZE_1" value="1"/>
+            <bitfield low="0" high="11" name="ID" scope="NV_PFIFO_PBDMA_STATUS"/>
+            <bitfield low="12" high="12" name="ID_TYPE" scope="NV_PFIFO_PBDMA_STATUS">
+                <enum name="ID_TYPE_CHID" value="0"/>
+                <enum name="ID_TYPE_TSGID" value="1"/>
+            </bitfield>
+            <bitfield low="13" high="15" name="CHAN_STATUS" scope="NV_PFIFO_PBDMA_STATUS">
+                <enum name="CHAN_STATUS_VALID" value="1"/>
+                <enum name="CHAN_STATUS_CHSW_LOAD" value="5"/>
+                <enum name="CHAN_STATUS_CHSW_SAVE" value="6"/>
+                <enum name="CHAN_STATUS_CHSW_SWITCH" value="7"/>
+            </bitfield>
+            <bitfield low="16" high="27" name="NEXT_ID" scope="NV_PFIFO_PBDMA_STATUS"/>
+            <bitfield low="28" high="28" name="NEXT_ID_TYPE" scope="NV_PFIFO_PBDMA_STATUS">
+                <enum name="NEXT_ID_TYPE_CHID" value="0"/>
+            </bitfield>
+            <bitfield low="15" high="15" name="CHSW" scope="NV_PFIFO_PBDMA_STATUS">
+                <enum name="CHSW_IN_PROGRESS" value="1"/>
+            </bitfield>
+        </reg32>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_graph.xml
+++ b/rnndb/gk20a/gk20a_graph.xml
@@ -1,0 +1,1153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_PGRAPH">
+        <reg32 offset="0x400100" name="INTR" variants="GK20A">
+            <bitfield low="0" high="0" name="NOTIFY" scope="NV_PGRAPH_INTR">
+                <enum name="NOTIFY_PENDING" value="1"/>
+                <enum name="NOTIFY_RESET" value="1"/>
+            </bitfield>
+            <bitfield low="1" high="1" name="SEMAPHORE" scope="NV_PGRAPH_INTR">
+                <enum name="SEMAPHORE_PENDING" value="1"/>
+                <enum name="SEMAPHORE_RESET" value="1"/>
+            </bitfield>
+            <bitfield low="2" high="2" name="SEMAPHORE_TIMEOUT" scope="NV_PGRAPH_INTR">
+                <enum name="SEMAPHORE_TIMEOUT_NOT_PENDING" value="0"/>
+                <enum name="SEMAPHORE_TIMEOUT_PENDING" value="1"/>
+                <enum name="SEMAPHORE_TIMEOUT_RESET" value="1"/>
+            </bitfield>
+            <bitfield low="4" high="4" name="ILLEGAL_METHOD" scope="NV_PGRAPH_INTR">
+                <enum name="ILLEGAL_METHOD_PENDING" value="1"/>
+                <enum name="ILLEGAL_METHOD_RESET" value="1"/>
+            </bitfield>
+            <bitfield low="6" high="6" name="ILLEGAL_NOTIFY" scope="NV_PGRAPH_INTR">
+                <enum name="ILLEGAL_NOTIFY_PENDING" value="1"/>
+                <enum name="ILLEGAL_NOTIFY_RESET" value="1"/>
+            </bitfield>
+            <bitfield low="8" high="8" name="FIRMWARE_METHOD" scope="NV_PGRAPH_INTR">
+                <enum name="FIRMWARE_METHOD_PENDING" value="1"/>
+                <enum name="FIRMWARE_METHOD_RESET" value="1"/>
+            </bitfield>
+            <bitfield low="5" high="5" name="ILLEGAL_CLASS" scope="NV_PGRAPH_INTR">
+                <enum name="ILLEGAL_CLASS_PENDING" value="1"/>
+                <enum name="ILLEGAL_CLASS_RESET" value="1"/>
+            </bitfield>
+            <bitfield low="19" high="19" name="FECS_ERROR" scope="NV_PGRAPH_INTR">
+                <enum name="FECS_ERROR_PENDING" value="1"/>
+                <enum name="FECS_ERROR_RESET" value="1"/>
+            </bitfield>
+            <bitfield low="20" high="20" name="CLASS_ERROR" scope="NV_PGRAPH_INTR">
+                <enum name="CLASS_ERROR_PENDING" value="1"/>
+                <enum name="CLASS_ERROR_RESET" value="1"/>
+            </bitfield>
+            <bitfield low="21" high="21" name="EXCEPTION" scope="NV_PGRAPH_INTR">
+                <enum name="EXCEPTION_PENDING" value="1"/>
+                <enum name="EXCEPTION_RESET" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x400144" name="FECS_INTR" variants="GK20A"/>
+        <reg32 offset="0x400110" name="CLASS_ERROR" variants="GK20A">
+            <bitfield low="0" high="15" name="CODE" scope="NV_PGRAPH_CLASS_ERROR"/>
+        </reg32>
+        <reg32 offset="0x400120" name="NONSTALL_INTR" variants="GK20A">
+            <bitfield low="1" high="1" name="TRAP" scope="NV_PGRAPH_NONSTALL_INTR">
+                <enum name="TRAP_PENDING" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x40013c" name="INTR_EN" variants="GK20A"/>
+        <reg32 offset="0x400108" name="EXCEPTION" variants="GK20A">
+            <bitfield low="0" high="0" name="FE" scope="NV_PGRAPH_EXCEPTION"/>
+            <bitfield low="24" high="24" name="GPC" scope="NV_PGRAPH_EXCEPTION"/>
+        </reg32>
+        <reg32 offset="0x400118" name="EXCEPTION1" variants="GK20A">
+            <bitfield low="0" high="31" name="GPC" scope="NV_PGRAPH_EXCEPTION1">
+                <enum name="GPC_0_PENDING" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x40011c" name="EXCEPTION2" variants="GK20A"/>
+        <reg32 offset="0x400138" name="EXCEPTION_EN" variants="GK20A">
+            <bitfield low="0" high="0" name="FE" scope="NV_PGRAPH_EXCEPTION_EN"/>
+        </reg32>
+        <reg32 offset="0x400130" name="EXCEPTION1_EN" variants="GK20A"/>
+        <reg32 offset="0x400134" name="EXCEPTION2_EN" variants="GK20A"/>
+        <reg32 offset="0x400500" name="GRFIFO_CONTROL" variants="GK20A">
+            <bitfield low="0" high="0" name="ACCESS" scope="NV_PGRAPH_GRFIFO_CONTROL">
+                <enum name="ACCESS_DISABLED" value="0"/>
+                <enum name="ACCESS_ENABLED" value="1"/>
+            </bitfield>
+            <bitfield low="16" high="16" name="SEMAPHORE_ACCESS" scope="NV_PGRAPH_GRFIFO_CONTROL">
+                <enum name="SEMAPHORE_ACCESS_ENABLED" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x400704" name="TRAPPED_ADDR" variants="GK20A">
+            <bitfield low="2" high="13" name="MTHD" scope="NV_PGRAPH_TRAPPED_ADDR"/>
+            <bitfield low="16" high="18" name="SUBCH" scope="NV_PGRAPH_TRAPPED_ADDR"/>
+        </reg32>
+        <reg32 offset="0x400708" name="TRAPPED_DATA_LOW" variants="GK20A"/>
+        <reg32 offset="0x40070c" name="TRAPPED_DATA_HIGH" variants="GK20A"/>
+        <reg32 offset="0x400700" name="STATUS" variants="GK20A">
+            <bitfield low="1" high="1" name="FE_METHOD_UPPER" scope="NV_PGRAPH_STATUS"/>
+            <bitfield low="2" high="2" name="FE_METHOD_LOWER" scope="NV_PGRAPH_STATUS">
+                <enum name="FE_METHOD_LOWER_IDLE" value="0"/>
+            </bitfield>
+            <bitfield low="21" high="21" name="FE_GI" scope="NV_PGRAPH_STATUS"/>
+        </reg32>
+        <reg32 offset="0x400610" name="STATUS_MASK" variants="GK20A"/>
+        <reg32 offset="0x40060c" name="ENGINE_STATUS" variants="GK20A">
+            <bitfield low="0" high="0" name="VALUE" scope="NV_PGRAPH_ENGINE_STATUS">
+                <enum name="VALUE_BUSY" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x400200" name="PIPE_BUNDLE_ADDRESS" variants="GK20A">
+            <bitfield low="0" high="15" name="VALUE" scope="NV_PGRAPH_PIPE_BUNDLE_ADDRESS"/>
+        </reg32>
+        <reg32 offset="0x400204" name="PIPE_BUNDLE_DATA" variants="GK20A"/>
+        <reg32 offset="0x400208" name="PIPE_BUNDLE_CONFIG" variants="GK20A">
+            <bitfield low="31" high="31" name="OVERRIDE_PIPE_MODE" scope="NV_PGRAPH_PIPE_BUNDLE_CONFIG">
+                <enum name="OVERRIDE_PIPE_MODE_DISABLED" value="0"/>
+                <enum name="OVERRIDE_PIPE_MODE_ENABLED" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x404000" name="PRI_FE_HWW_ESR" variants="GK20A">
+            <bitfield low="30" high="30" name="RESET" scope="NV_PGRAPH_PRI_FE_HWW_ESR">
+                <enum name="RESET_ACTIVE" value="1"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="EN" scope="NV_PGRAPH_PRI_FE_HWW_ESR">
+                <enum name="EN_ENABLE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x404154" name="PRI_FE_GO_IDLE_TIMEOUT" variants="GK20A">
+            <bitfield low="0" high="31" name="COUNT" scope="NV_PGRAPH_PRI_FE_GO_IDLE_TIMEOUT">
+                <enum name="COUNT_DISABLED" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x404200" name="PRI_FE_OBJECT_TABLE" variants="GK20A">
+            <bitfield low="0" high="15" name="NVCLASS" scope="NV_PGRAPH_PRI_FE_OBJECT_TABLE"/>
+        </reg32>
+        <reg32 offset="0x404488" name="PRI_MME_SHADOW_RAM_INDEX" variants="GK20A">
+            <bitfield low="31" high="31" name="WRITE" scope="NV_PGRAPH_PRI_MME_SHADOW_RAM_INDEX">
+                <enum name="WRITE_TRIGGER" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x40448c" name="PRI_MME_SHADOW_RAM_DATA" variants="GK20A"/>
+        <reg32 offset="0x404490" name="PRI_MME_HWW_ESR" variants="GK20A">
+            <bitfield low="30" high="30" name="RESET" scope="NV_PGRAPH_PRI_MME_HWW_ESR">
+                <enum name="RESET_ACTIVE" value="1"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="EN" scope="NV_PGRAPH_PRI_MME_HWW_ESR">
+                <enum name="EN_ENABLE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x404600" name="PRI_MEMFMT_HWW_ESR" variants="GK20A">
+            <bitfield low="30" high="30" name="RESET" scope="NV_PGRAPH_PRI_MEMFMT_HWW_ESR">
+                <enum name="RESET_ACTIVE" value="1"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="EN" scope="NV_PGRAPH_PRI_MEMFMT_HWW_ESR">
+                <enum name="EN_ENABLE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x409100" name="PRI_FECS_FALCON_CPUCTL" variants="GK20A">
+            <bitfield low="1" high="1" name="STARTCPU" scope="NV_PGRAPH_PRI_FECS_FALCON_CPUCTL"/>
+        </reg32>
+        <reg32 offset="0x40910c" name="PRI_FECS_FALCON_DMACTL" variants="GK20A">
+            <bitfield low="0" high="0" name="REQUIRE_CTX" scope="NV_PGRAPH_PRI_FECS_FALCON_DMACTL"/>
+            <bitfield low="1" high="1" name="DMEM_SCRUBBING" scope="NV_PGRAPH_PRI_FECS_FALCON_DMACTL"/>
+            <bitfield low="2" high="2" name="IMEM_SCRUBBING" scope="NV_PGRAPH_PRI_FECS_FALCON_DMACTL"/>
+        </reg32>
+        <reg32 offset="0x409080" name="PRI_FECS_FALCON_OS" variants="GK20A"/>
+        <reg32 offset="0x40904c" name="PRI_FECS_FALCON_IDLESTATE" variants="GK20A"/>
+        <reg32 offset="0x409040" name="PRI_FECS_FALCON_MAILBOX0" variants="GK20A"/>
+        <reg32 offset="0x409044" name="PRI_FECS_FALCON_MAILBOX1" variants="GK20A"/>
+        <reg32 offset="0x409008" name="PRI_FECS_FALCON_IRQSTAT" variants="GK20A"/>
+        <reg32 offset="0x40900c" name="PRI_FECS_FALCON_IRQMODE" variants="GK20A"/>
+        <reg32 offset="0x409018" name="PRI_FECS_FALCON_IRQMASK" variants="GK20A"/>
+        <reg32 offset="0x40901c" name="PRI_FECS_FALCON_IRQDEST" variants="GK20A"/>
+        <reg32 offset="0x409050" name="PRI_FECS_FALCON_CURCTX" variants="GK20A"/>
+        <reg32 offset="0x409054" name="PRI_FECS_FALCON_NXTCTX" variants="GK20A"/>
+        <reg32 offset="0x4090a4" name="PRI_FECS_FALCON_ENGCTL" variants="GK20A"/>
+        <reg32 offset="0x409090" name="PRI_FECS_FALCON_DEBUG1" variants="GK20A"/>
+        <reg32 offset="0x409094" name="PRI_FECS_FALCON_DEBUGINFO" variants="GK20A"/>
+        <reg32 offset="0x409200" name="PRI_FECS_FALCON_ICD_CMD" variants="GK20A">
+            <bitfield low="0" high="3" name="OPC" scope="NV_PGRAPH_PRI_FECS_FALCON_ICD_CMD">
+                <enum name="OPC_RREG" value="8"/>
+                <enum name="OPC_RSTAT" value="14"/>
+            </bitfield>
+            <bitfield low="8" high="12" name="IDX" scope="NV_PGRAPH_PRI_FECS_FALCON_ICD_CMD"/>
+        </reg32>
+        <reg32 offset="0x40920c" name="PRI_FECS_FALCON_ICD_RDATA" variants="GK20A"/>
+        <reg32 offset="0x409180" name="PRI_FECS_FALCON_IMEMC" variants="GK20A">
+            <bitfield low="2" high="7" name="OFFS" scope="NV_PGRAPH_PRI_FECS_FALCON_IMEMC"/>
+            <bitfield low="8" high="15" name="BLK" scope="NV_PGRAPH_PRI_FECS_FALCON_IMEMC"/>
+            <bitfield low="24" high="24" name="AINCW" scope="NV_PGRAPH_PRI_FECS_FALCON_IMEMC"/>
+        </reg32>
+        <reg32 offset="0x409184" name="PRI_FECS_FALCON_IMEMD" variants="GK20A"/>
+        <reg32 offset="0x409188" name="PRI_FECS_FALCON_IMEMT" variants="GK20A">
+            <bitfield low="0" high="15" name="TAG" scope="NV_PGRAPH_PRI_FECS_FALCON_IMEMT"/>
+        </reg32>
+        <reg32 offset="0x4091c0" name="PRI_FECS_FALCON_DMEMC" variants="GK20A">
+            <bitfield low="2" high="7" name="OFFS" scope="NV_PGRAPH_PRI_FECS_FALCON_DMEMC"/>
+            <bitfield low="8" high="15" name="BLK" scope="NV_PGRAPH_PRI_FECS_FALCON_DMEMC"/>
+            <bitfield low="24" high="24" name="AINCW" scope="NV_PGRAPH_PRI_FECS_FALCON_DMEMC"/>
+        </reg32>
+        <reg32 offset="0x4091c4" name="PRI_FECS_FALCON_DMEMD" variants="GK20A"/>
+        <reg32 offset="0x409110" name="PRI_FECS_FALCON_DMATRFBASE" variants="GK20A"/>
+        <reg32 offset="0x409114" name="PRI_FECS_FALCON_DMATRFMOFFS" variants="GK20A"/>
+        <reg32 offset="0x40911c" name="PRI_FECS_FALCON_DMATRFFBOFFS" variants="GK20A"/>
+        <reg32 offset="0x409118" name="PRI_FECS_FALCON_DMATRFCMD" variants="GK20A">
+            <bitfield low="4" high="4" name="IMEM" scope="NV_PGRAPH_PRI_FECS_FALCON_DMATRFCMD"/>
+            <bitfield low="5" high="5" name="WRITE" scope="NV_PGRAPH_PRI_FECS_FALCON_DMATRFCMD"/>
+            <bitfield low="8" high="10" name="SIZE" scope="NV_PGRAPH_PRI_FECS_FALCON_DMATRFCMD"/>
+            <bitfield low="12" high="14" name="CTXDMA" scope="NV_PGRAPH_PRI_FECS_FALCON_DMATRFCMD"/>
+        </reg32>
+        <reg32 offset="0x409104" name="PRI_FECS_FALCON_BOOTVEC" variants="GK20A">
+            <bitfield low="0" high="31" name="VEC" scope="NV_PGRAPH_PRI_FECS_FALCON_BOOTVEC"/>
+        </reg32>
+        <reg32 offset="0x409108" name="PRI_FECS_FALCON_HWCFG" variants="GK20A"/>
+        <reg32 offset="0x41a108" name="PRI_GPCS_GPCCS_FALCON_HWCFG" variants="GK20A"/>
+        <reg32 offset="0x409084" name="PRI_FECS_FALCON_RM" variants="GK20A"/>
+        <reg32 offset="0x409b00" name="PRI_FECS_CURRENT_CTX" variants="GK20A">
+            <bitfield low="0" high="27" name="PTR" scope="NV_PGRAPH_PRI_FECS_CURRENT_CTX"/>
+            <bitfield low="28" high="29" name="TARGET" scope="NV_PGRAPH_PRI_FECS_CURRENT_CTX"/>
+            <bitfield low="28" high="29" name="TARGET" scope="NV_PGRAPH_PRI_FECS_CURRENT_CTX">
+                <enum name="TARGET_VID_MEM" value="0"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="VALID" scope="NV_PGRAPH_PRI_FECS_CURRENT_CTX">
+                <enum name="VALID_FALSE" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x409500" name="PRI_FECS_METHOD_DATA" variants="GK20A"/>
+        <reg32 offset="0x409504" name="PRI_FECS_METHOD_PUSH" variants="GK20A">
+            <bitfield low="0" high="11" name="ADR" scope="NV_PGRAPH_PRI_FECS_METHOD_PUSH">
+                <enum name="ADR_BIND_POINTER" value="3"/>
+                <enum name="ADR_DISCOVER_IMAGE_SIZE" value="16"/>
+                <enum name="ADR_WFI_GOLDEN_SAVE" value="9"/>
+                <enum name="ADR_RESTORE_GOLDEN" value="21"/>
+                <enum name="ADR_DISCOVER_ZCULL_IMAGE_SIZE" value="22"/>
+                <enum name="ADR_DISCOVER_PM_IMAGE_SIZE" value="37"/>
+                <enum name="ADR_DISCOVER_REGLIST_IMAGE_SIZE" value="48"/>
+                <enum name="ADR_SET_REGLIST_BIND_INSTANCE" value="49"/>
+                <enum name="ADR_SET_REGLIST_VIRTUAL_ADDRESS" value="50"/>
+                <enum name="ADR_STOP_CTXSW" value="56"/>
+                <enum name="ADR_START_CTXSW" value="57"/>
+                <enum name="ADR_SET_WATCHDOG_TIMEOUT" value="33"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x409c18" name="PRI_FECS_HOST_INT_STATUS" variants="GK20A">
+            <bitfield low="17" high="17" name="UMIMP_FIRMWARE_METHOD" scope="NV_PGRAPH_PRI_FECS_HOST_INT_STATUS"/>
+            <bitfield low="18" high="18" name="UMIMP_ILLEGAL_METHOD" scope="NV_PGRAPH_PRI_FECS_HOST_INT_STATUS"/>
+        </reg32>
+        <reg32 offset="0x409c20" name="PRI_FECS_HOST_INT_CLEAR" variants="GK20A"/>
+        <reg32 offset="0x409c24" name="PRI_FECS_HOST_INT_ENABLE" variants="GK20A">
+            <bitfield low="16" high="16" name="FAULT_DURING_CTXSW" scope="NV_PGRAPH_PRI_FECS_HOST_INT_ENABLE">
+                <enum name="FAULT_DURING_CTXSW_ENABLE" value="1"/>
+            </bitfield>
+            <bitfield low="17" high="17" name="UMIMP_FIRMWARE_METHOD" scope="NV_PGRAPH_PRI_FECS_HOST_INT_ENABLE">
+                <enum name="UMIMP_FIRMWARE_METHOD_ENABLE" value="1"/>
+            </bitfield>
+            <bitfield low="18" high="18" name="UMIMP_ILLEGAL_METHOD" scope="NV_PGRAPH_PRI_FECS_HOST_INT_ENABLE">
+                <enum name="UMIMP_ILLEGAL_METHOD_ENABLE" value="1"/>
+            </bitfield>
+            <bitfield low="19" high="19" name="WATCHDOG" scope="NV_PGRAPH_PRI_FECS_HOST_INT_ENABLE">
+                <enum name="WATCHDOG_ENABLE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x409614" name="PRI_FECS_CTXSW_RESET_CTL" variants="GK20A">
+            <bitfield low="0" high="0" name="SYS_HALT" scope="NV_PGRAPH_PRI_FECS_CTXSW_RESET_CTL">
+                <enum name="SYS_HALT_DISABLED" value="0"/>
+            </bitfield>
+            <bitfield low="1" high="1" name="GPC_HALT" scope="NV_PGRAPH_PRI_FECS_CTXSW_RESET_CTL">
+                <enum name="GPC_HALT_DISABLED" value="0"/>
+            </bitfield>
+            <bitfield low="2" high="2" name="BE_HALT" scope="NV_PGRAPH_PRI_FECS_CTXSW_RESET_CTL">
+                <enum name="BE_HALT_DISABLED" value="0"/>
+            </bitfield>
+            <bitfield low="4" high="4" name="SYS_ENGINE_RESET" scope="NV_PGRAPH_PRI_FECS_CTXSW_RESET_CTL">
+                <enum name="SYS_ENGINE_RESET_DISABLED" value="1"/>
+            </bitfield>
+            <bitfield low="5" high="5" name="GPC_ENGINE_RESET" scope="NV_PGRAPH_PRI_FECS_CTXSW_RESET_CTL">
+                <enum name="GPC_ENGINE_RESET_DISABLED" value="1"/>
+            </bitfield>
+            <bitfield low="6" high="6" name="BE_ENGINE_RESET" scope="NV_PGRAPH_PRI_FECS_CTXSW_RESET_CTL">
+                <enum name="BE_ENGINE_RESET_DISABLED" value="1"/>
+            </bitfield>
+            <bitfield low="8" high="8" name="SYS_CONTEXT_RESET" scope="NV_PGRAPH_PRI_FECS_CTXSW_RESET_CTL">
+                <enum name="SYS_CONTEXT_RESET_ENABLED" value="0"/>
+                <enum name="SYS_CONTEXT_RESET_DISABLED" value="1"/>
+            </bitfield>
+            <bitfield low="9" high="9" name="GPC_CONTEXT_RESET" scope="NV_PGRAPH_PRI_FECS_CTXSW_RESET_CTL">
+                <enum name="GPC_CONTEXT_RESET_ENABLED" value="0"/>
+                <enum name="GPC_CONTEXT_RESET_DISABLED" value="1"/>
+            </bitfield>
+            <bitfield low="10" high="10" name="BE_CONTEXT_RESET" scope="NV_PGRAPH_PRI_FECS_CTXSW_RESET_CTL">
+                <enum name="BE_CONTEXT_RESET_ENABLED" value="0"/>
+                <enum name="BE_CONTEXT_RESET_DISABLED" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x40960c" name="PRI_FECS_CTX_STATE_STORE_MAJOR_REV_ID" variants="GK20A"/>
+        <reg32 offset="0x409800" name="PRI_FECS_CTXSW_MAILBOX" variants="GK20A">
+            <enum name="_SIZE_1" value="8"/>
+            <bitfield low="0" high="31" name="VALUE" scope="NV_PGRAPH_PRI_FECS_CTXSW_MAILBOX">
+                <enum name="VALUE_PASS" value="1"/>
+                <enum name="VALUE_FAIL" value="2"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x409820" name="PRI_FECS_CTXSW_MAILBOX_SET" variants="GK20A">
+            <bitfield low="0" high="31" name="VALUE" scope="NV_PGRAPH_PRI_FECS_CTXSW_MAILBOX_SET"/>
+        </reg32>
+        <reg32 offset="0x409840" name="PRI_FECS_CTXSW_MAILBOX_CLEAR" variants="GK20A">
+            <bitfield low="0" high="31" name="VALUE" scope="NV_PGRAPH_PRI_FECS_CTXSW_MAILBOX_CLEAR"/>
+        </reg32>
+        <reg32 offset="0x409604" name="PRI_FECS_FS" variants="GK20A">
+            <bitfield low="0" high="4" name="NUM_AVAILABLE_GPCS" scope="NV_PGRAPH_PRI_FECS_FS"/>
+            <bitfield low="16" high="20" name="NUM_AVAILABLE_FBPS" scope="NV_PGRAPH_PRI_FECS_FS"/>
+        </reg32>
+        <reg32 offset="0x409620" name="PRI_FECS_CFG_FALCON" variants="GK20A">
+            <bitfield low="0" high="7" name="IMEM_SZ" scope="NV_PGRAPH_PRI_FECS_CFG_FALCON"/>
+        </reg32>
+        <reg32 offset="0x409880" name="PRI_FECS_RC_LANES" variants="GK20A">
+            <bitfield low="0" high="5" name="NUM_CHAINS" scope="NV_PGRAPH_PRI_FECS_RC_LANES"/>
+        </reg32>
+        <reg32 offset="0x409400" name="PRI_FECS_CTXSW_STATUS_1" variants="GK20A">
+            <bitfield low="12" high="12" name="ARB_BUSY" scope="NV_PGRAPH_PRI_FECS_CTXSW_STATUS_1"/>
+        </reg32>
+        <reg32 offset="0x409a24" name="PRI_FECS_ARB_CTX_ADR" variants="GK20A"/>
+        <reg32 offset="0x409b04" name="PRI_FECS_NEW_CTX" variants="GK20A">
+            <bitfield low="0" high="27" name="PTR" scope="NV_PGRAPH_PRI_FECS_NEW_CTX"/>
+            <bitfield low="28" high="29" name="TARGET" scope="NV_PGRAPH_PRI_FECS_NEW_CTX"/>
+            <bitfield low="31" high="31" name="VALID" scope="NV_PGRAPH_PRI_FECS_NEW_CTX"/>
+        </reg32>
+        <reg32 offset="0x409a0c" name="PRI_FECS_ARB_CTX_PTR" variants="GK20A">
+            <bitfield low="0" high="27" name="PTR" scope="NV_PGRAPH_PRI_FECS_ARB_CTX_PTR"/>
+            <bitfield low="28" high="29" name="TARGET" scope="NV_PGRAPH_PRI_FECS_ARB_CTX_PTR"/>
+        </reg32>
+        <reg32 offset="0x409a10" name="PRI_FECS_ARB_CTX_CMD" variants="GK20A">
+            <bitfield low="0" high="4" name="CMD" scope="NV_PGRAPH_PRI_FECS_ARB_CTX_CMD"/>
+        </reg32>
+        <reg32 offset="0x40780c" name="PRI_RSTR2D_GPC_MAP0" variants="GK20A"/>
+        <reg32 offset="0x407810" name="PRI_RSTR2D_GPC_MAP1" variants="GK20A"/>
+        <reg32 offset="0x407814" name="PRI_RSTR2D_GPC_MAP2" variants="GK20A"/>
+        <reg32 offset="0x407818" name="PRI_RSTR2D_GPC_MAP3" variants="GK20A"/>
+        <reg32 offset="0x40781c" name="PRI_RSTR2D_GPC_MAP4" variants="GK20A"/>
+        <reg32 offset="0x407820" name="PRI_RSTR2D_GPC_MAP5" variants="GK20A"/>
+        <reg32 offset="0x4078bc" name="PRI_RSTR2D_MAP_TABLE_CONFIG" variants="GK20A">
+            <bitfield low="0" high="7" name="ROW_OFFSET" scope="NV_PGRAPH_PRI_RSTR2D_MAP_TABLE_CONFIG"/>
+            <bitfield low="8" high="15" name="NUM_ENTRIES" scope="NV_PGRAPH_PRI_RSTR2D_MAP_TABLE_CONFIG"/>
+        </reg32>
+        <reg32 offset="0x406018" name="PRI_PD_HWW_ESR" variants="GK20A">
+            <bitfield low="30" high="30" name="RESET" scope="NV_PGRAPH_PRI_PD_HWW_ESR">
+                <enum name="RESET_ACTIVE" value="1"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="EN" scope="NV_PGRAPH_PRI_PD_HWW_ESR">
+                <enum name="EN_ENABLE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x406028" name="PRI_PD_NUM_TPC_PER_GPC" variants="GK20A">
+            <enum name="_SIZE_1" value="4"/>
+            <bitfield low="0" high="3" name="COUNT0" scope="NV_PGRAPH_PRI_PD_NUM_TPC_PER_GPC"/>
+            <bitfield low="4" high="7" name="COUNT1" scope="NV_PGRAPH_PRI_PD_NUM_TPC_PER_GPC"/>
+            <bitfield low="8" high="11" name="COUNT2" scope="NV_PGRAPH_PRI_PD_NUM_TPC_PER_GPC"/>
+            <bitfield low="12" high="15" name="COUNT3" scope="NV_PGRAPH_PRI_PD_NUM_TPC_PER_GPC"/>
+            <bitfield low="16" high="19" name="COUNT4" scope="NV_PGRAPH_PRI_PD_NUM_TPC_PER_GPC"/>
+            <bitfield low="20" high="23" name="COUNT5" scope="NV_PGRAPH_PRI_PD_NUM_TPC_PER_GPC"/>
+            <bitfield low="24" high="27" name="COUNT6" scope="NV_PGRAPH_PRI_PD_NUM_TPC_PER_GPC"/>
+            <bitfield low="28" high="31" name="COUNT7" scope="NV_PGRAPH_PRI_PD_NUM_TPC_PER_GPC"/>
+        </reg32>
+        <reg32 offset="0x4064c0" name="PRI_PD_AB_DIST_CONFIG_0" variants="GK20A">
+            <bitfield low="31" high="31" name="TIMESLICE_ENABLE" scope="NV_PGRAPH_PRI_PD_AB_DIST_CONFIG_0">
+                <enum name="TIMESLICE_ENABLE_EN" value="1"/>
+                <enum name="TIMESLICE_ENABLE_DIS" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x4064c4" name="PRI_PD_AB_DIST_CONFIG_1" variants="GK20A">
+            <bitfield low="0" high="15" name="MAX_BATCHES" scope="NV_PGRAPH_PRI_PD_AB_DIST_CONFIG_1">
+                <enum name="MAX_BATCHES_INIT" value="65535"/>
+            </bitfield>
+            <bitfield low="16" high="26" name="MAX_OUTPUT" scope="NV_PGRAPH_PRI_PD_AB_DIST_CONFIG_1">
+                <enum name="MAX_OUTPUT_GRANULARITY" value="128"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x4064c8" name="PRI_PD_AB_DIST_CONFIG_2" variants="GK20A">
+            <bitfield low="0" high="11" name="TOKEN_LIMIT" scope="NV_PGRAPH_PRI_PD_AB_DIST_CONFIG_2">
+                <enum name="TOKEN_LIMIT_INIT" value="256"/>
+            </bitfield>
+            <bitfield low="16" high="27" name="STATE_LIMIT" scope="NV_PGRAPH_PRI_PD_AB_DIST_CONFIG_2">
+                <enum name="STATE_LIMIT_SCC_BUNDLE_GRANULARITY" value="32"/>
+                <enum name="STATE_LIMIT_MIN_GPM_FIFO_DEPTHS" value="98"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x4064cc" name="PRI_PD_RM_PAGEPOOL" variants="GK20A">
+            <bitfield low="0" high="7" name="TOTAL_PAGES" scope="NV_PGRAPH_PRI_PD_RM_PAGEPOOL"/>
+            <bitfield low="31" high="31" name="VALID" scope="NV_PGRAPH_PRI_PD_RM_PAGEPOOL">
+                <enum name="VALID_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x4064d0" name="PRI_PD_DIST_SKIP_TABLE" variants="GK20A">
+            <enum name="_SIZE_1" value="8"/>
+            <bitfield low="0" high="7" name="GPC_4N0_MASK" scope="NV_PGRAPH_PRI_PD_DIST_SKIP_TABLE"/>
+            <bitfield low="8" high="15" name="GPC_4N1_MASK" scope="NV_PGRAPH_PRI_PD_DIST_SKIP_TABLE"/>
+            <bitfield low="16" high="23" name="GPC_4N2_MASK" scope="NV_PGRAPH_PRI_PD_DIST_SKIP_TABLE"/>
+            <bitfield low="24" high="31" name="GPC_4N3_MASK" scope="NV_PGRAPH_PRI_PD_DIST_SKIP_TABLE"/>
+        </reg32>
+        <reg32 offset="0x406800" name="PRI_PD_ALPHA_RATIO_TABLE" variants="GK20A">
+            <enum name="_SIZE_1" value="256"/>
+            <bitfield low="0" high="7" name="GPC_4N0_MASK" scope="NV_PGRAPH_PRI_PD_ALPHA_RATIO_TABLE"/>
+            <bitfield low="8" high="15" name="GPC_4N1_MASK" scope="NV_PGRAPH_PRI_PD_ALPHA_RATIO_TABLE"/>
+            <bitfield low="16" high="23" name="GPC_4N2_MASK" scope="NV_PGRAPH_PRI_PD_ALPHA_RATIO_TABLE"/>
+            <bitfield low="24" high="31" name="GPC_4N3_MASK" scope="NV_PGRAPH_PRI_PD_ALPHA_RATIO_TABLE"/>
+        </reg32>
+        <reg32 offset="0x406c00" name="PRI_PD_BETA_RATIO_TABLE" variants="GK20A">
+            <enum name="_SIZE_1" value="256"/>
+            <bitfield low="0" high="7" name="GPC_4N0_MASK" scope="NV_PGRAPH_PRI_PD_BETA_RATIO_TABLE"/>
+            <bitfield low="8" high="15" name="GPC_4N1_MASK" scope="NV_PGRAPH_PRI_PD_BETA_RATIO_TABLE"/>
+            <bitfield low="16" high="23" name="GPC_4N2_MASK" scope="NV_PGRAPH_PRI_PD_BETA_RATIO_TABLE"/>
+            <bitfield low="24" high="31" name="GPC_4N3_MASK" scope="NV_PGRAPH_PRI_PD_BETA_RATIO_TABLE"/>
+        </reg32>
+        <reg32 offset="0x405800" name="PRI_DS_DEBUG" variants="GK20A">
+            <bitfield low="27" high="27" name="TIMESLICE_MODE" scope="NV_PGRAPH_PRI_DS_DEBUG">
+                <enum name="TIMESLICE_MODE_DISABLE" value="0"/>
+                <enum name="TIMESLICE_MODE_ENABLE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x405804" name="PRI_DS_ZBC_COLOR_R" variants="GK20A">
+            <bitfield low="0" high="31" name="VAL" scope="NV_PGRAPH_PRI_DS_ZBC_COLOR_R"/>
+        </reg32>
+        <reg32 offset="0x405808" name="PRI_DS_ZBC_COLOR_G" variants="GK20A">
+            <bitfield low="0" high="31" name="VAL" scope="NV_PGRAPH_PRI_DS_ZBC_COLOR_G"/>
+        </reg32>
+        <reg32 offset="0x40580c" name="PRI_DS_ZBC_COLOR_B" variants="GK20A">
+            <bitfield low="0" high="31" name="VAL" scope="NV_PGRAPH_PRI_DS_ZBC_COLOR_B"/>
+        </reg32>
+        <reg32 offset="0x405810" name="PRI_DS_ZBC_COLOR_A" variants="GK20A">
+            <bitfield low="0" high="31" name="VAL" scope="NV_PGRAPH_PRI_DS_ZBC_COLOR_A"/>
+        </reg32>
+        <reg32 offset="0x405814" name="PRI_DS_ZBC_COLOR_FMT" variants="GK20A">
+            <bitfield low="0" high="6" name="VAL" scope="NV_PGRAPH_PRI_DS_ZBC_COLOR_FMT">
+                <enum name="VAL_INVALID" value="0"/>
+                <enum name="VAL_ZERO" value="1"/>
+                <enum name="VAL_UNORM_ONE" value="2"/>
+                <enum name="VAL_RF32_GF32_BF32_AF32" value="4"/>
+                <enum name="VAL_A8B8G8R8" value="40"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x405818" name="PRI_DS_ZBC_Z" variants="GK20A">
+            <bitfield low="0" high="31" name="VAL" scope="NV_PGRAPH_PRI_DS_ZBC_Z">
+                <enum name="VAL__INIT" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x40581c" name="PRI_DS_ZBC_Z_FMT" variants="GK20A">
+            <bitfield low="0" high="0" name="VAL" scope="NV_PGRAPH_PRI_DS_ZBC_Z_FMT">
+                <enum name="VAL_INVALID" value="0"/>
+                <enum name="VAL_FP32" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x405820" name="PRI_DS_ZBC_TBL_INDEX" variants="GK20A">
+            <bitfield low="0" high="3" name="VAL" scope="NV_PGRAPH_PRI_DS_ZBC_TBL_INDEX"/>
+        </reg32>
+        <reg32 offset="0x405824" name="PRI_DS_ZBC_TBL_LD" variants="GK20A">
+            <bitfield low="0" high="0" name="SELECT" scope="NV_PGRAPH_PRI_DS_ZBC_TBL_LD">
+                <enum name="SELECT_C" value="0"/>
+                <enum name="SELECT_Z" value="1"/>
+            </bitfield>
+            <bitfield low="1" high="1" name="ACTION" scope="NV_PGRAPH_PRI_DS_ZBC_TBL_LD">
+                <enum name="ACTION_WRITE" value="0"/>
+            </bitfield>
+            <bitfield low="2" high="2" name="TRIGGER" scope="NV_PGRAPH_PRI_DS_ZBC_TBL_LD">
+                <enum name="TRIGGER_ACTIVE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x405830" name="PRI_DS_TGA_CONSTRAINTLOGIC" variants="GK20A">
+            <bitfield low="16" high="27" name="BETA_CBSIZE" scope="NV_PGRAPH_PRI_DS_TGA_CONSTRAINTLOGIC"/>
+            <bitfield low="0" high="11" name="ALPHA_CBSIZE" scope="NV_PGRAPH_PRI_DS_TGA_CONSTRAINTLOGIC"/>
+        </reg32>
+        <reg32 offset="0x405840" name="PRI_DS_HWW_ESR" variants="GK20A">
+            <bitfield low="30" high="30" name="RESET" scope="NV_PGRAPH_PRI_DS_HWW_ESR">
+                <enum name="RESET_TASK" value="1"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="EN" scope="NV_PGRAPH_PRI_DS_HWW_ESR">
+                <enum name="EN_ENABLED" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x405844" name="PRI_DS_HWW_REPORT_MASK" variants="GK20A">
+            <bitfield low="0" high="0" name="SPH0_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH0_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="1" high="1" name="SPH1_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH1_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="2" high="2" name="SPH2_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH2_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="3" high="3" name="SPH3_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH3_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="4" high="4" name="SPH4_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH4_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="5" high="5" name="SPH5_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH5_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="6" high="6" name="SPH6_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH6_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="7" high="7" name="SPH7_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH7_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="8" high="8" name="SPH8_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH8_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="9" high="9" name="SPH9_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH9_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="10" high="10" name="SPH10_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH10_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="11" high="11" name="SPH11_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH11_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="12" high="12" name="SPH12_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH12_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="13" high="13" name="SPH13_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH13_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="14" high="14" name="SPH14_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH14_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="15" high="15" name="SPH15_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH15_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="16" high="16" name="SPH16_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH16_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="17" high="17" name="SPH17_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH17_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="18" high="18" name="SPH18_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH18_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="19" high="19" name="SPH19_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH19_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="20" high="20" name="SPH20_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH20_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="21" high="21" name="SPH21_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH21_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="22" high="22" name="SPH22_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH22_ERR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="23" high="23" name="SPH23_ERR" scope="NV_PGRAPH_PRI_DS_HWW_REPORT_MASK">
+                <enum name="SPH23_ERR_REPORT" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x405870" name="PRI_DS_NUM_TPC_PER_GPC" variants="GK20A"/>
+        <reg32 offset="0x408004" name="PRI_SCC_RM_BUNDLE_CB_BASE" variants="GK20A">
+            <bitfield low="0" high="31" name="ADDR_39_8" scope="NV_PGRAPH_PRI_SCC_RM_BUNDLE_CB_BASE">
+                <enum name="ADDR_39_8_ALIGN_BITS" value="8"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x408008" name="PRI_SCC_RM_BUNDLE_CB_SIZE" variants="GK20A">
+            <bitfield low="0" high="10" name="DIV_256B" scope="NV_PGRAPH_PRI_SCC_RM_BUNDLE_CB_SIZE">
+                <enum name="DIV_256B__PROD" value="24"/>
+                <enum name="DIV_256B_BYTE_GRANULARITY" value="256"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="VALID" scope="NV_PGRAPH_PRI_SCC_RM_BUNDLE_CB_SIZE">
+                <enum name="VALID_FALSE" value="0"/>
+                <enum name="VALID_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x40800c" name="PRI_SCC_RM_PAGEPOOL_BASE" variants="GK20A">
+            <bitfield low="0" high="31" name="ADDR_39_8" scope="NV_PGRAPH_PRI_SCC_RM_PAGEPOOL_BASE">
+                <enum name="ADDR_39_8_ALIGN_BITS" value="8"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x408010" name="PRI_SCC_RM_PAGEPOOL" variants="GK20A">
+            <bitfield low="0" high="7" name="TOTAL_PAGES" scope="NV_PGRAPH_PRI_SCC_RM_PAGEPOOL">
+                <enum name="TOTAL_PAGES_HWMAX" value="0"/>
+                <enum name="TOTAL_PAGES_HWMAX_VALUE" value="128"/>
+                <enum name="TOTAL_PAGES_BYTE_GRANULARITY" value="256"/>
+            </bitfield>
+            <bitfield low="8" high="15" name="MAX_VALID_PAGES" scope="NV_PGRAPH_PRI_SCC_RM_PAGEPOOL"/>
+            <bitfield low="31" high="31" name="VALID" scope="NV_PGRAPH_PRI_SCC_RM_PAGEPOOL">
+                <enum name="VALID_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x40802c" name="PRI_SCC_INIT" variants="GK20A">
+            <bitfield low="0" high="0" name="RAM" scope="NV_PGRAPH_PRI_SCC_INIT">
+                <enum name="RAM_TRIGGER" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x408030" name="PRI_SCC_HWW_ESR" variants="GK20A">
+            <bitfield low="30" high="30" name="RESET" scope="NV_PGRAPH_PRI_SCC_HWW_ESR">
+                <enum name="RESET_ACTIVE" value="1"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="EN" scope="NV_PGRAPH_PRI_SCC_HWW_ESR">
+                <enum name="EN_ENABLE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x407020" name="PRI_SKED_HWW_ESR" variants="GK20A">
+            <bitfield low="30" high="30" name="RESET" scope="NV_PGRAPH_PRI_SKED_HWW_ESR">
+                <enum name="RESET_ACTIVE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x405b00" name="PRI_CWD_FS" variants="GK20A">
+            <bitfield low="0" high="7" name="NUM_GPCS" scope="NV_PGRAPH_PRI_CWD_FS"/>
+            <bitfield low="8" high="15" name="NUM_TPCS" scope="NV_PGRAPH_PRI_CWD_FS"/>
+        </reg32>
+        <reg32 offset="0x502608" name="PRI_GPC0_GPCCS_FS_GPC" variants="GK20A">
+            <bitfield low="0" high="4" name="NUM_AVAILABLE_TPCS" scope="NV_PGRAPH_PRI_GPC0_GPCCS_FS_GPC"/>
+            <bitfield low="16" high="20" name="NUM_AVAILABLE_ZCULLS" scope="NV_PGRAPH_PRI_GPC0_GPCCS_FS_GPC"/>
+        </reg32>
+        <reg32 offset="0x502620" name="PRI_GPC0_GPCCS_CFG_FALCON" variants="GK20A">
+            <bitfield low="0" high="7" name="IMEM_SZ" scope="NV_PGRAPH_PRI_GPC0_GPCCS_CFG_FALCON"/>
+        </reg32>
+        <reg32 offset="0x502880" name="PRI_GPC0_GPCCS_RC_LANES" variants="GK20A">
+            <bitfield low="0" high="5" name="NUM_CHAINS" scope="NV_PGRAPH_PRI_GPC0_GPCCS_RC_LANES"/>
+        </reg32>
+        <reg32 offset="0x502910" name="PRI_GPC0_GPCCS_RC_LANE_SIZE" variants="GK20A">
+            <enum name="_SIZE_1" value="16"/>
+            <bitfield low="0" high="23" name="V" scope="NV_PGRAPH_PRI_GPC0_GPCCS_RC_LANE_SIZE">
+                <enum name="V_0" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x500910" name="PRI_GPC0_ZCULL_FS" variants="GK20A">
+            <bitfield low="0" high="8" name="NUM_SMS" scope="NV_PGRAPH_PRI_GPC0_ZCULL_FS"/>
+            <bitfield low="16" high="19" name="NUM_ACTIVE_BANKS" scope="NV_PGRAPH_PRI_GPC0_ZCULL_FS"/>
+        </reg32>
+        <reg32 offset="0x500914" name="PRI_GPC0_ZCULL_RAM_ADDR" variants="GK20A">
+            <bitfield low="0" high="3" name="TILES_PER_HYPERTILE_ROW_PER_GPC" scope="NV_PGRAPH_PRI_GPC0_ZCULL_RAM_ADDR"/>
+            <bitfield low="8" high="11" name="ROW_OFFSET" scope="NV_PGRAPH_PRI_GPC0_ZCULL_RAM_ADDR"/>
+        </reg32>
+        <reg32 offset="0x500918" name="PRI_GPC0_ZCULL_SM_NUM_RCP" variants="GK20A">
+            <bitfield low="0" high="23" name="CONSERVATIVE" scope="NV_PGRAPH_PRI_GPC0_ZCULL_SM_NUM_RCP">
+                <enum name="CONSERVATIVE__MAX" value="8388608"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x500920" name="PRI_GPC0_ZCULL_TOTAL_RAM_SIZE" variants="GK20A">
+            <bitfield low="0" high="15" name="NUM_ALIQUOTS" scope="NV_PGRAPH_PRI_GPC0_ZCULL_TOTAL_RAM_SIZE"/>
+        </reg32>
+        <reg32 offset="0x500a04" name="PRI_GPC0_ZCULL_ZCSIZE" variants="GK20A">
+            <bitfield low="1" high="12" name="HEIGHT" scope="NV_PGRAPH_PRI_GPC0_ZCULL_ZCSIZE">
+                <enum name="HEIGHT_SUBREGION__MULTIPLE" value="64"/>
+            </bitfield>
+            <bitfield low="16" high="28" name="WIDTH" scope="NV_PGRAPH_PRI_GPC0_ZCULL_ZCSIZE">
+                <enum name="WIDTH_SUBREGION__MULTIPLE" value="16"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x500c08" name="PRI_GPC0_GPM_PD_ACTIVE_TPCS" variants="GK20A">
+            <bitfield low="0" high="2" name="NUM" scope="NV_PGRAPH_PRI_GPC0_GPM_PD_ACTIVE_TPCS"/>
+        </reg32>
+        <reg32 offset="0x500c10" name="PRI_GPC0_GPM_PD_SM_ID" variants="GK20A">
+            <bitfield low="0" high="7" name="ID" scope="NV_PGRAPH_PRI_GPC0_GPM_PD_SM_ID"/>
+        </reg32>
+        <reg32 offset="0x500c30" name="PRI_GPC0_GPM_PD_PES_TPC_ID_MASK" variants="GK20A">
+            <bitfield low="0" high="7" name="MASK" scope="NV_PGRAPH_PRI_GPC0_GPM_PD_PES_TPC_ID_MASK"/>
+        </reg32>
+        <reg32 offset="0x500c8c" name="PRI_GPC0_GPM_SD_ACTIVE_TPCS" variants="GK20A">
+            <bitfield low="0" high="2" name="NUM" scope="NV_PGRAPH_PRI_GPC0_GPM_SD_ACTIVE_TPCS"/>
+        </reg32>
+        <reg32 offset="0x504088" name="PRI_GPC0_TPC0_PE_CFG_SMID" variants="GK20A">
+            <bitfield low="0" high="15" name="VALUE" scope="NV_PGRAPH_PRI_GPC0_TPC0_PE_CFG_SMID"/>
+        </reg32>
+        <reg32 offset="0x5044e8" name="PRI_GPC0_TPC0_L1C_CFG_SMID" variants="GK20A">
+            <bitfield low="0" high="15" name="VALUE" scope="NV_PGRAPH_PRI_GPC0_TPC0_L1C_CFG_SMID"/>
+        </reg32>
+        <reg32 offset="0x504698" name="PRI_GPC0_TPC0_SM_CONFIG" variants="GK20A">
+            <bitfield low="0" high="15" name="SM_ID" scope="NV_PGRAPH_PRI_GPC0_TPC0_SM_CONFIG"/>
+        </reg32>
+        <reg32 offset="0x50469c" name="PRI_GPC0_TPC0_SM_ARCH" variants="GK20A">
+            <bitfield low="0" high="7" name="WARP_COUNT" scope="NV_PGRAPH_PRI_GPC0_TPC0_SM_ARCH"/>
+            <bitfield low="8" high="11" name="SPA_VERSION" scope="NV_PGRAPH_PRI_GPC0_TPC0_SM_ARCH">
+                <enum name="SPA_VERSION_SMKEPLER_LP" value="12"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x503018" name="PRI_GPC0_PPC0_PES_VSC_STREAM" variants="GK20A">
+            <bitfield low="0" high="0" name="MASTER_PE" scope="NV_PGRAPH_PRI_GPC0_PPC0_PES_VSC_STREAM">
+                <enum name="MASTER_PE_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x5030c0" name="PRI_GPC0_PPC0_CBM_CONFIG" variants="GK20A">
+            <bitfield low="0" high="15" name="START_OFFSET" scope="NV_PGRAPH_PRI_GPC0_PPC0_CBM_CONFIG"/>
+            <bitfield low="16" high="27" name="SIZE" scope="NV_PGRAPH_PRI_GPC0_PPC0_CBM_CONFIG">
+                <enum name="SIZE_DEFAULT" value="576"/>
+                <enum name="SIZE_GRANULARITY" value="32"/>
+            </bitfield>
+            <bitfield low="28" high="28" name="TIMESLICE_MODE" scope="NV_PGRAPH_PRI_GPC0_PPC0_CBM_CONFIG"/>
+        </reg32>
+        <reg32 offset="0x5030e4" name="PRI_GPC0_PPC0_CBM_CONFIG2" variants="GK20A">
+            <bitfield low="0" high="15" name="START_OFFSET" scope="NV_PGRAPH_PRI_GPC0_PPC0_CBM_CONFIG2"/>
+            <bitfield low="16" high="27" name="SIZE" scope="NV_PGRAPH_PRI_GPC0_PPC0_CBM_CONFIG2">
+                <enum name="SIZE_DEFAULT" value="1608"/>
+                <enum name="SIZE_GRANULARITY" value="32"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x41a0ac" name="PRI_GPCS_GPCCS_FALCON_ADDR" variants="GK20A">
+            <bitfield low="0" high="5" name="LSB" scope="NV_PGRAPH_PRI_GPCS_GPCCS_FALCON_ADDR">
+                <enum name="LSB_INIT" value="0"/>
+            </bitfield>
+            <bitfield low="6" high="11" name="MSB" scope="NV_PGRAPH_PRI_GPCS_GPCCS_FALCON_ADDR">
+                <enum name="MSB_INIT" value="0"/>
+            </bitfield>
+            <bitfield low="0" high="11" name="EXT" scope="NV_PGRAPH_PRI_GPCS_GPCCS_FALCON_ADDR"/>
+        </reg32>
+        <reg32 offset="0x41a100" name="PRI_GPCS_GPCCS_FALCON_CPUCTL" variants="GK20A">
+            <bitfield low="1" high="1" name="STARTCPU" scope="NV_PGRAPH_PRI_GPCS_GPCCS_FALCON_CPUCTL"/>
+        </reg32>
+        <reg32 offset="0x41a10c" name="PRI_GPCS_GPCCS_FALCON_DMACTL" variants="GK20A">
+            <bitfield low="0" high="0" name="REQUIRE_CTX" scope="NV_PGRAPH_PRI_GPCS_GPCCS_FALCON_DMACTL"/>
+            <bitfield low="1" high="1" name="DMEM_SCRUBBING" scope="NV_PGRAPH_PRI_GPCS_GPCCS_FALCON_DMACTL"/>
+            <bitfield low="2" high="2" name="IMEM_SCRUBBING" scope="NV_PGRAPH_PRI_GPCS_GPCCS_FALCON_DMACTL"/>
+        </reg32>
+        <reg32 offset="0x41a180" name="PRI_GPCS_GPCCS_FALCON_IMEMC" variants="GK20A">
+            <bitfield low="2" high="7" name="OFFS" scope="NV_PGRAPH_PRI_GPCS_GPCCS_FALCON_IMEMC"/>
+            <bitfield low="8" high="15" name="BLK" scope="NV_PGRAPH_PRI_GPCS_GPCCS_FALCON_IMEMC"/>
+            <bitfield low="24" high="24" name="AINCW" scope="NV_PGRAPH_PRI_GPCS_GPCCS_FALCON_IMEMC"/>
+        </reg32>
+        <reg32 offset="0x41a184" name="PRI_GPCS_GPCCS_FALCON_IMEMD" variants="GK20A"/>
+        <reg32 offset="0x41a188" name="PRI_GPCS_GPCCS_FALCON_IMEMT" variants="GK20A">
+            <enum name="_SIZE_1" value="4"/>
+            <bitfield low="0" high="15" name="TAG" scope="NV_PGRAPH_PRI_GPCS_GPCCS_FALCON_IMEMT"/>
+        </reg32>
+        <reg32 offset="0x41a1c0" name="PRI_GPCS_GPCCS_FALCON_DMEMC" variants="GK20A">
+            <bitfield low="2" high="7" name="OFFS" scope="NV_PGRAPH_PRI_GPCS_GPCCS_FALCON_DMEMC"/>
+            <bitfield low="8" high="15" name="BLK" scope="NV_PGRAPH_PRI_GPCS_GPCCS_FALCON_DMEMC"/>
+            <bitfield low="24" high="24" name="AINCW" scope="NV_PGRAPH_PRI_GPCS_GPCCS_FALCON_DMEMC"/>
+        </reg32>
+        <reg32 offset="0x41a1c4" name="PRI_GPCS_GPCCS_FALCON_DMEMD" variants="GK20A"/>
+        <reg32 offset="0x41a800" name="PRI_GPCS_GPCCS_CTXSW_MAILBOX" variants="GK20A">
+            <bitfield low="0" high="31" name="VALUE" scope="NV_PGRAPH_PRI_GPCS_GPCCS_CTXSW_MAILBOX"/>
+        </reg32>
+        <reg32 offset="0x418808" name="PRI_GPCS_SETUP_RM_BUNDLE_CB_BASE" variants="GK20A">
+            <bitfield low="0" high="31" name="ADDR_39_8" scope="NV_PGRAPH_PRI_GPCS_SETUP_RM_BUNDLE_CB_BASE">
+                <enum name="ADDR_39_8_INIT" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x41880c" name="PRI_GPCS_SETUP_RM_BUNDLE_CB_SIZE" variants="GK20A">
+            <bitfield low="0" high="10" name="DIV_256B" scope="NV_PGRAPH_PRI_GPCS_SETUP_RM_BUNDLE_CB_SIZE">
+                <enum name="DIV_256B_INIT" value="0"/>
+                <enum name="DIV_256B__PROD" value="24"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="VALID" scope="NV_PGRAPH_PRI_GPCS_SETUP_RM_BUNDLE_CB_SIZE">
+                <enum name="VALID_FALSE" value="0"/>
+                <enum name="VALID_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x418810" name="PRI_GPCS_SETUP_RM_ATTRIB_CB_BASE" variants="GK20A">
+            <bitfield low="0" high="27" name="ADDR_39_12" scope="NV_PGRAPH_PRI_GPCS_SETUP_RM_ATTRIB_CB_BASE">
+                <enum name="ADDR_39_12_ALIGN_BITS" value="12"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="VALID" scope="NV_PGRAPH_PRI_GPCS_SETUP_RM_ATTRIB_CB_BASE">
+                <enum name="VALID_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x418b08" name="PRI_GPCS_CRSTR_GPC_MAP0" variants="GK20A">
+            <bitfield low="0" high="2" name="TILE0" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP0"/>
+            <bitfield low="5" high="7" name="TILE1" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP0"/>
+            <bitfield low="10" high="12" name="TILE2" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP0"/>
+            <bitfield low="15" high="17" name="TILE3" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP0"/>
+            <bitfield low="20" high="22" name="TILE4" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP0"/>
+            <bitfield low="25" high="27" name="TILE5" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP0"/>
+        </reg32>
+        <reg32 offset="0x418b0c" name="PRI_GPCS_CRSTR_GPC_MAP1" variants="GK20A">
+            <bitfield low="0" high="2" name="TILE6" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP1"/>
+            <bitfield low="5" high="7" name="TILE7" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP1"/>
+            <bitfield low="10" high="12" name="TILE8" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP1"/>
+            <bitfield low="15" high="17" name="TILE9" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP1"/>
+            <bitfield low="20" high="22" name="TILE10" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP1"/>
+            <bitfield low="25" high="27" name="TILE11" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP1"/>
+        </reg32>
+        <reg32 offset="0x418b10" name="PRI_GPCS_CRSTR_GPC_MAP2" variants="GK20A">
+            <bitfield low="0" high="2" name="TILE12" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP2"/>
+            <bitfield low="5" high="7" name="TILE13" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP2"/>
+            <bitfield low="10" high="12" name="TILE14" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP2"/>
+            <bitfield low="15" high="17" name="TILE15" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP2"/>
+            <bitfield low="20" high="22" name="TILE16" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP2"/>
+            <bitfield low="25" high="27" name="TILE17" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP2"/>
+        </reg32>
+        <reg32 offset="0x418b14" name="PRI_GPCS_CRSTR_GPC_MAP3" variants="GK20A">
+            <bitfield low="0" high="2" name="TILE18" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP3"/>
+            <bitfield low="5" high="7" name="TILE19" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP3"/>
+            <bitfield low="10" high="12" name="TILE20" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP3"/>
+            <bitfield low="15" high="17" name="TILE21" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP3"/>
+            <bitfield low="20" high="22" name="TILE22" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP3"/>
+            <bitfield low="25" high="27" name="TILE23" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP3"/>
+        </reg32>
+        <reg32 offset="0x418b18" name="PRI_GPCS_CRSTR_GPC_MAP4" variants="GK20A">
+            <bitfield low="0" high="2" name="TILE24" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP4"/>
+            <bitfield low="5" high="7" name="TILE25" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP4"/>
+            <bitfield low="10" high="12" name="TILE26" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP4"/>
+            <bitfield low="15" high="17" name="TILE27" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP4"/>
+            <bitfield low="20" high="22" name="TILE28" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP4"/>
+            <bitfield low="25" high="27" name="TILE29" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP4"/>
+        </reg32>
+        <reg32 offset="0x418b1c" name="PRI_GPCS_CRSTR_GPC_MAP5" variants="GK20A">
+            <bitfield low="0" high="2" name="TILE30" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP5"/>
+            <bitfield low="5" high="7" name="TILE31" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP5"/>
+            <bitfield low="10" high="12" name="TILE32" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP5"/>
+            <bitfield low="15" high="17" name="TILE33" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP5"/>
+            <bitfield low="20" high="22" name="TILE34" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP5"/>
+            <bitfield low="25" high="27" name="TILE35" scope="NV_PGRAPH_PRI_GPCS_CRSTR_GPC_MAP5"/>
+        </reg32>
+        <reg32 offset="0x418bb8" name="PRI_GPCS_CRSTR_MAP_TABLE_CONFIG" variants="GK20A">
+            <bitfield low="0" high="7" name="ROW_OFFSET" scope="NV_PGRAPH_PRI_GPCS_CRSTR_MAP_TABLE_CONFIG"/>
+            <bitfield low="8" high="15" name="NUM_ENTRIES" scope="NV_PGRAPH_PRI_GPCS_CRSTR_MAP_TABLE_CONFIG"/>
+        </reg32>
+        <reg32 offset="0x418980" name="PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP0" variants="GK20A">
+            <bitfield low="0" high="2" name="TILE_0" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP0"/>
+            <bitfield low="4" high="6" name="TILE_1" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP0"/>
+            <bitfield low="8" high="10" name="TILE_2" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP0"/>
+            <bitfield low="12" high="14" name="TILE_3" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP0"/>
+            <bitfield low="16" high="18" name="TILE_4" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP0"/>
+            <bitfield low="20" high="22" name="TILE_5" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP0"/>
+            <bitfield low="24" high="26" name="TILE_6" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP0"/>
+            <bitfield low="28" high="30" name="TILE_7" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP0"/>
+        </reg32>
+        <reg32 offset="0x418984" name="PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP1" variants="GK20A">
+            <bitfield low="0" high="2" name="TILE_8" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP1"/>
+            <bitfield low="4" high="6" name="TILE_9" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP1"/>
+            <bitfield low="8" high="10" name="TILE_10" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP1"/>
+            <bitfield low="12" high="14" name="TILE_11" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP1"/>
+            <bitfield low="16" high="18" name="TILE_12" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP1"/>
+            <bitfield low="20" high="22" name="TILE_13" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP1"/>
+            <bitfield low="24" high="26" name="TILE_14" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP1"/>
+            <bitfield low="28" high="30" name="TILE_15" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP1"/>
+        </reg32>
+        <reg32 offset="0x418988" name="PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP2" variants="GK20A">
+            <bitfield low="0" high="2" name="TILE_16" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP2"/>
+            <bitfield low="4" high="6" name="TILE_17" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP2"/>
+            <bitfield low="8" high="10" name="TILE_18" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP2"/>
+            <bitfield low="12" high="14" name="TILE_19" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP2"/>
+            <bitfield low="16" high="18" name="TILE_20" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP2"/>
+            <bitfield low="20" high="22" name="TILE_21" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP2"/>
+            <bitfield low="24" high="26" name="TILE_22" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP2"/>
+            <bitfield low="28" high="30" name="TILE_23" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP2"/>
+        </reg32>
+        <reg32 offset="0x41898c" name="PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP3" variants="GK20A">
+            <bitfield low="0" high="2" name="TILE_24" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP3"/>
+            <bitfield low="4" high="6" name="TILE_25" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP3"/>
+            <bitfield low="8" high="10" name="TILE_26" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP3"/>
+            <bitfield low="12" high="14" name="TILE_27" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP3"/>
+            <bitfield low="16" high="18" name="TILE_28" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP3"/>
+            <bitfield low="20" high="22" name="TILE_29" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP3"/>
+            <bitfield low="24" high="26" name="TILE_30" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP3"/>
+            <bitfield low="28" high="30" name="TILE_31" scope="NV_PGRAPH_PRI_GPCS_ZCULL_SM_IN_GPC_NUMBER_MAP3"/>
+        </reg32>
+        <reg32 offset="0x418c6c" name="PRI_GPCS_GPM_PD_CONFIG" variants="GK20A">
+            <bitfield low="0" high="0" name="TIMESLICE_MODE" scope="NV_PGRAPH_PRI_GPCS_GPM_PD_CONFIG">
+                <enum name="TIMESLICE_MODE_DISABLE" value="0"/>
+                <enum name="TIMESLICE_MODE_ENABLE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x419004" name="PRI_GPCS_GCC_RM_PAGEPOOL_BASE" variants="GK20A">
+            <bitfield low="0" high="31" name="ADDR_39_8" scope="NV_PGRAPH_PRI_GPCS_GCC_RM_PAGEPOOL_BASE"/>
+        </reg32>
+        <reg32 offset="0x419008" name="PRI_GPCS_GCC_RM_PAGEPOOL" variants="GK20A">
+            <bitfield low="0" high="7" name="TOTAL_PAGES" scope="NV_PGRAPH_PRI_GPCS_GCC_RM_PAGEPOOL"/>
+        </reg32>
+        <reg32 offset="0x41980c" name="PRI_GPCS_TPCS_PE_VAF" variants="GK20A">
+            <bitfield low="4" high="4" name="FAST_MODE_SWITCH" scope="NV_PGRAPH_PRI_GPCS_TPCS_PE_VAF">
+                <enum name="FAST_MODE_SWITCH_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x419848" name="PRI_GPCS_TPCS_PE_PIN_CB_GLOBAL_BASE_ADDR" variants="GK20A">
+            <bitfield low="0" high="27" name="V" scope="NV_PGRAPH_PRI_GPCS_TPCS_PE_PIN_CB_GLOBAL_BASE_ADDR"/>
+            <bitfield low="28" high="28" name="VALID" scope="NV_PGRAPH_PRI_GPCS_TPCS_PE_PIN_CB_GLOBAL_BASE_ADDR">
+                <enum name="VALID_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x419c00" name="PRI_GPCS_TPCS_MPC_VTG_DEBUG" variants="GK20A">
+            <bitfield low="3" high="3" name="TIMESLICE_MODE" scope="NV_PGRAPH_PRI_GPCS_TPCS_MPC_VTG_DEBUG">
+                <enum name="TIMESLICE_MODE_DISABLED" value="0"/>
+                <enum name="TIMESLICE_MODE_ENABLED" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x419e44" name="PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK" variants="GK20A">
+            <bitfield low="1" high="1" name="STACK_ERROR" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="STACK_ERROR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="2" high="2" name="API_STACK_ERROR" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="API_STACK_ERROR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="3" high="3" name="RET_EMPTY_STACK_ERROR" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="RET_EMPTY_STACK_ERROR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="4" high="4" name="PC_WRAP" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="PC_WRAP_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="5" high="5" name="MISALIGNED_PC" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="MISALIGNED_PC_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="6" high="6" name="PC_OVERFLOW" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="PC_OVERFLOW_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="7" high="7" name="MISALIGNED_IMMC_ADDR" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="MISALIGNED_IMMC_ADDR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="8" high="8" name="MISALIGNED_REG" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="MISALIGNED_REG_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="9" high="9" name="ILLEGAL_INSTR_ENCODING" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="ILLEGAL_INSTR_ENCODING_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="10" high="10" name="ILLEGAL_SPH_INSTR_COMBO" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="ILLEGAL_SPH_INSTR_COMBO_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="11" high="11" name="ILLEGAL_INSTR_PARAM" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="ILLEGAL_INSTR_PARAM_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="12" high="12" name="INVALID_CONST_ADDR" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="INVALID_CONST_ADDR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="13" high="13" name="OOR_REG" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="OOR_REG_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="14" high="14" name="OOR_ADDR" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="OOR_ADDR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="15" high="15" name="MISALIGNED_ADDR" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="MISALIGNED_ADDR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="16" high="16" name="INVALID_ADDR_SPACE" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="INVALID_ADDR_SPACE_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="17" high="17" name="ILLEGAL_INSTR_PARAM2" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="ILLEGAL_INSTR_PARAM2_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="18" high="18" name="INVALID_CONST_ADDR_LDC" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="INVALID_CONST_ADDR_LDC_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="19" high="19" name="GEOMETRY_SM_ERROR" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="GEOMETRY_SM_ERROR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="20" high="20" name="DIVERGENT" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_WARP_ESR_REPORT_MASK">
+                <enum name="DIVERGENT_REPORT" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x419e4c" name="PRI_GPCS_TPCS_SM_HWW_GLOBAL_ESR_REPORT_MASK" variants="GK20A">
+            <bitfield low="0" high="0" name="SM_TO_SM_FAULT" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_GLOBAL_ESR_REPORT_MASK">
+                <enum name="SM_TO_SM_FAULT_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="1" high="1" name="L1_ERROR" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_GLOBAL_ESR_REPORT_MASK">
+                <enum name="L1_ERROR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="2" high="2" name="MULTIPLE_WARP_ERRORS" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_GLOBAL_ESR_REPORT_MASK">
+                <enum name="MULTIPLE_WARP_ERRORS_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="3" high="3" name="PHYSICAL_STACK_OVERFLOW_ERROR" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_GLOBAL_ESR_REPORT_MASK">
+                <enum name="PHYSICAL_STACK_OVERFLOW_ERROR_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="4" high="4" name="BPT_INT" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_GLOBAL_ESR_REPORT_MASK">
+                <enum name="BPT_INT_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="5" high="5" name="BPT_PAUSE" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_GLOBAL_ESR_REPORT_MASK">
+                <enum name="BPT_PAUSE_REPORT" value="1"/>
+            </bitfield>
+            <bitfield low="6" high="6" name="SINGLE_STEP_COMPLETE" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_GLOBAL_ESR_REPORT_MASK">
+                <enum name="SINGLE_STEP_COMPLETE_REPORT" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x419d0c" name="PRI_GPCS_TPCS_TPCCS_TPC_EXCEPTION_EN" variants="GK20A">
+            <bitfield low="1" high="1" name="NV_PGRAPH_PRI_GPC0_TPC0_TPCCS_TPC_EXCEPTION_EN_SM" scope="NV_PGRAPH_PRI_GPCS_TPCS_TPCCS_TPC_EXCEPTION_EN">
+                <enum name="NV_PGRAPH_PRI_GPC0_TPC0_TPCCS_TPC_EXCEPTION_EN_SM_ENABLED" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x50450c" name="PRI_GPC0_TPC0_TPCCS_TPC_EXCEPTION_EN" variants="GK20A">
+            <bitfield low="1" high="1" name="SM" scope="NV_PGRAPH_PRI_GPC0_TPC0_TPCCS_TPC_EXCEPTION_EN">
+                <enum name="SM_ENABLED" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x41ac94" name="PRI_GPCS_GPCCS_GPC_EXCEPTION_EN" variants="GK20A">
+            <bitfield low="16" high="23" name="TPC" scope="NV_PGRAPH_PRI_GPCS_GPCCS_GPC_EXCEPTION_EN"/>
+        </reg32>
+        <reg32 offset="0x502c90" name="PRI_GPC0_GPCCS_GPC_EXCEPTION" variants="GK20A">
+            <bitfield low="16" high="23" name="TPC" scope="NV_PGRAPH_PRI_GPC0_GPCCS_GPC_EXCEPTION">
+                <enum name="TPC_0_PENDING" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x504508" name="PRI_GPC0_TPC0_TPCCS_TPC_EXCEPTION" variants="GK20A">
+            <bitfield low="1" high="1" name="SM" scope="NV_PGRAPH_PRI_GPC0_TPC0_TPCCS_TPC_EXCEPTION">
+                <enum name="SM_PENDING" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x504610" name="PRI_GPC0_TPC0_SM_DBGR_CONTROL0" variants="GK20A">
+            <bitfield low="0" high="0" name="DEBUGGER_MODE" scope="NV_PGRAPH_PRI_GPC0_TPC0_SM_DBGR_CONTROL0">
+                <enum name="DEBUGGER_MODE_ON" value="1"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="STOP_TRIGGER" scope="NV_PGRAPH_PRI_GPC0_TPC0_SM_DBGR_CONTROL0">
+                <enum name="STOP_TRIGGER_ENABLE" value="1"/>
+                <enum name="STOP_TRIGGER_DISABLE" value="0"/>
+            </bitfield>
+            <bitfield low="30" high="30" name="RUN_TRIGGER" scope="NV_PGRAPH_PRI_GPC0_TPC0_SM_DBGR_CONTROL0">
+                <enum name="RUN_TRIGGER_TASK" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x50460c" name="PRI_GPC0_TPC0_SM_DBGR_STATUS0" variants="GK20A">
+            <bitfield low="4" high="4" name="LOCKED_DOWN" scope="NV_PGRAPH_PRI_GPC0_TPC0_SM_DBGR_STATUS0">
+                <enum name="LOCKED_DOWN_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x419e50" name="PRI_GPCS_TPCS_SM_HWW_GLOBAL_ESR" variants="GK20A">
+            <bitfield low="4" high="4" name="BPT_INT" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_GLOBAL_ESR">
+                <enum name="BPT_INT_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="5" high="5" name="BPT_PAUSE" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_GLOBAL_ESR">
+                <enum name="BPT_PAUSE_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="6" high="6" name="SINGLE_STEP_COMPLETE" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HWW_GLOBAL_ESR">
+                <enum name="SINGLE_STEP_COMPLETE_PENDING" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x504650" name="PRI_GPC0_TPC0_SM_HWW_GLOBAL_ESR" variants="GK20A">
+            <bitfield low="4" high="4" name="BPT_INT" scope="NV_PGRAPH_PRI_GPC0_TPC0_SM_HWW_GLOBAL_ESR">
+                <enum name="BPT_INT_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="5" high="5" name="BPT_PAUSE" scope="NV_PGRAPH_PRI_GPC0_TPC0_SM_HWW_GLOBAL_ESR">
+                <enum name="BPT_PAUSE_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="6" high="6" name="SINGLE_STEP_COMPLETE" scope="NV_PGRAPH_PRI_GPC0_TPC0_SM_HWW_GLOBAL_ESR">
+                <enum name="SINGLE_STEP_COMPLETE_PENDING" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x504648" name="PRI_GPC0_TPC0_SM_HWW_WARP_ESR" variants="GK20A">
+            <bitfield low="0" high="15" name="ERROR" scope="NV_PGRAPH_PRI_GPC0_TPC0_SM_HWW_WARP_ESR">
+                <enum name="ERROR_NONE" value="0"/>
+                <enum name="ERROR_NONE" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x504770" name="PRI_GPC0_TPC0_SM_HALFCTL_CTRL" variants="GK20A"/>
+        <reg32 offset="0x419f70" name="PRI_GPCS_TPCS_SM_HALFCTL_CTRL" variants="GK20A">
+            <bitfield low="4" high="4" name="SCTL_READ_QUAD_CTL" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HALFCTL_CTRL"/>
+            <bitfield low="4" high="4" name="SCTL_READ_QUAD_CTL" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_HALFCTL_CTRL"/>
+        </reg32>
+        <reg32 offset="0x50477c" name="PRI_GPC0_TPC0_SM_DEBUG_SFE_CONTROL" variants="GK20A"/>
+        <reg32 offset="0x419f7c" name="PRI_GPCS_TPCS_SM_DEBUG_SFE_CONTROL" variants="GK20A">
+            <bitfield low="0" high="0" name="READ_HALF_CTL" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_DEBUG_SFE_CONTROL"/>
+            <bitfield low="0" high="0" name="READ_HALF_CTL" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_DEBUG_SFE_CONTROL"/>
+        </reg32>
+        <reg32 offset="0x41be08" name="PRI_GPCS_PPCS_PES_VSC_VPC" variants="GK20A">
+            <bitfield low="2" high="2" name="FAST_MODE_SWITCH" scope="NV_PGRAPH_PRI_GPCS_PPCS_PES_VSC_VPC">
+                <enum name="FAST_MODE_SWITCH_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x41bf00" name="PRI_GPCS_PPCS_WWDX_GPC_MAP0" variants="GK20A"/>
+        <reg32 offset="0x41bf04" name="PRI_GPCS_PPCS_WWDX_GPC_MAP1" variants="GK20A"/>
+        <reg32 offset="0x41bf08" name="PRI_GPCS_PPCS_WWDX_GPC_MAP2" variants="GK20A"/>
+        <reg32 offset="0x41bf0c" name="PRI_GPCS_PPCS_WWDX_GPC_MAP3" variants="GK20A"/>
+        <reg32 offset="0x41bf10" name="PRI_GPCS_PPCS_WWDX_GPC_MAP4" variants="GK20A"/>
+        <reg32 offset="0x41bf14" name="PRI_GPCS_PPCS_WWDX_GPC_MAP5" variants="GK20A"/>
+        <reg32 offset="0x41bfd0" name="PRI_GPCS_PPCS_WWDX_MAP_TABLE_CONFIG" variants="GK20A">
+            <bitfield low="0" high="7" name="ROW_OFFSET" scope="NV_PGRAPH_PRI_GPCS_PPCS_WWDX_MAP_TABLE_CONFIG"/>
+            <bitfield low="8" high="15" name="NUM_ENTRIES" scope="NV_PGRAPH_PRI_GPCS_PPCS_WWDX_MAP_TABLE_CONFIG"/>
+            <bitfield low="16" high="20" name="NORMALIZED_NUM_ENTRIES" scope="NV_PGRAPH_PRI_GPCS_PPCS_WWDX_MAP_TABLE_CONFIG"/>
+            <bitfield low="21" high="23" name="NORMALIZED_SHIFT_VALUE" scope="NV_PGRAPH_PRI_GPCS_PPCS_WWDX_MAP_TABLE_CONFIG"/>
+            <bitfield low="24" high="28" name="COEFF5_MOD_VALUE" scope="NV_PGRAPH_PRI_GPCS_PPCS_WWDX_MAP_TABLE_CONFIG"/>
+        </reg32>
+        <reg32 offset="0x41bfd4" name="PRI_GPCS_PPCS_WWDX_SM_NUM_RCP" variants="GK20A">
+            <bitfield low="0" high="23" name="CONSERVATIVE" scope="NV_PGRAPH_PRI_GPCS_PPCS_WWDX_SM_NUM_RCP"/>
+        </reg32>
+        <reg32 offset="0x41bfe4" name="PRI_GPCS_PPCS_WWDX_MAP_TABLE_CONFIG2" variants="GK20A">
+            <bitfield low="0" high="4" name="COEFF6_MOD_VALUE" scope="NV_PGRAPH_PRI_GPCS_PPCS_WWDX_MAP_TABLE_CONFIG2"/>
+            <bitfield low="5" high="9" name="COEFF7_MOD_VALUE" scope="NV_PGRAPH_PRI_GPCS_PPCS_WWDX_MAP_TABLE_CONFIG2"/>
+            <bitfield low="10" high="14" name="COEFF8_MOD_VALUE" scope="NV_PGRAPH_PRI_GPCS_PPCS_WWDX_MAP_TABLE_CONFIG2"/>
+            <bitfield low="15" high="19" name="COEFF9_MOD_VALUE" scope="NV_PGRAPH_PRI_GPCS_PPCS_WWDX_MAP_TABLE_CONFIG2"/>
+            <bitfield low="20" high="24" name="COEFF10_MOD_VALUE" scope="NV_PGRAPH_PRI_GPCS_PPCS_WWDX_MAP_TABLE_CONFIG2"/>
+            <bitfield low="25" high="29" name="COEFF11_MOD_VALUE" scope="NV_PGRAPH_PRI_GPCS_PPCS_WWDX_MAP_TABLE_CONFIG2"/>
+        </reg32>
+        <reg32 offset="0x41bec0" name="PRI_GPCS_PPCS_CBM_CONFIG" variants="GK20A">
+            <bitfield low="28" high="28" name="TIMESLICE_MODE" scope="NV_PGRAPH_PRI_GPCS_PPCS_CBM_CONFIG">
+                <enum name="TIMESLICE_MODE_ENABLE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x408850" name="PRI_BES_ZROP_SETTINGS" variants="GK20A">
+            <bitfield low="0" high="3" name="NUM_ACTIVE_FBPS" scope="NV_PGRAPH_PRI_BES_ZROP_SETTINGS"/>
+        </reg32>
+        <reg32 offset="0x408958" name="PRI_BES_CROP_SETTINGS" variants="GK20A">
+            <bitfield low="0" high="3" name="NUM_ACTIVE_FBPS" scope="NV_PGRAPH_PRI_BES_CROP_SETTINGS"/>
+        </reg32>
+        <enum name="NV_PZCULL_BYTES_PER_ALIQUOT_PER_GPC" value="32"/>
+        <enum name="NV_PZCULL_SAVE_RESTORE_HEADER_BYTES_PER_GPC" value="32"/>
+        <enum name="NV_PZCULL_SAVE_RESTORE_SUBREGION_HEADER_BYTES_PER_GPC" value="192"/>
+        <enum name="NV_PZCULL_SUBREGION_QTY" value="16"/>
+        <reg32 offset="0x504604" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER_CONTROL_SEL0" variants="GK20A"/>
+        <reg32 offset="0x504608" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER_CONTROL_SEL1" variants="GK20A"/>
+        <reg32 offset="0x50465c" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER_CONTROL0" variants="GK20A"/>
+        <reg32 offset="0x504660" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER_CONTROL1" variants="GK20A"/>
+        <reg32 offset="0x504664" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER_CONTROL2" variants="GK20A"/>
+        <reg32 offset="0x504668" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER_CONTROL3" variants="GK20A"/>
+        <reg32 offset="0x50466c" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER_CONTROL4" variants="GK20A"/>
+        <reg32 offset="0x504658" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER_CONTROL5" variants="GK20A"/>
+        <reg32 offset="0x504670" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER_STATUS" variants="GK20A"/>
+        <reg32 offset="0x504694" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER_STATUS1" variants="GK20A"/>
+        <reg32 offset="0x504730" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER0_CONTROL" variants="GK20A"/>
+        <reg32 offset="0x504734" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER1_CONTROL" variants="GK20A"/>
+        <reg32 offset="0x504738" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER2_CONTROL" variants="GK20A"/>
+        <reg32 offset="0x50473c" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER3_CONTROL" variants="GK20A"/>
+        <reg32 offset="0x504740" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER4_CONTROL" variants="GK20A"/>
+        <reg32 offset="0x504744" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER5_CONTROL" variants="GK20A"/>
+        <reg32 offset="0x504748" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER6_CONTROL" variants="GK20A"/>
+        <reg32 offset="0x50474c" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER7_CONTROL" variants="GK20A"/>
+        <reg32 offset="0x504674" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER0" variants="GK20A"/>
+        <reg32 offset="0x504678" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER1" variants="GK20A"/>
+        <reg32 offset="0x50467c" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER2" variants="GK20A"/>
+        <reg32 offset="0x504680" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER3" variants="GK20A"/>
+        <reg32 offset="0x504684" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER4" variants="GK20A"/>
+        <reg32 offset="0x504688" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER5" variants="GK20A"/>
+        <reg32 offset="0x50468c" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER6" variants="GK20A"/>
+        <reg32 offset="0x504690" name="PRI_GPC0_TPC0_SM_DSM_PERF_COUNTER7" variants="GK20A"/>
+        <reg32 offset="0x404170" name="PRI_FE_PWR_MODE" variants="GK20A">
+            <bitfield low="0" high="1" name="MODE" scope="NV_PGRAPH_PRI_FE_PWR_MODE">
+                <enum name="MODE_AUTO" value="0"/>
+                <enum name="MODE_FORCE_ON" value="2"/>
+            </bitfield>
+            <bitfield low="4" high="4" name="REQ" scope="NV_PGRAPH_PRI_FE_PWR_MODE">
+                <enum name="REQ_SEND" value="1"/>
+                <enum name="REQ_DONE" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x5044b0" name="PRI_GPC0_TPC0_L1C_DBG" variants="GK20A">
+            <bitfield low="27" high="27" name="CYA15" scope="NV_PGRAPH_PRI_GPC0_TPC0_L1C_DBG">
+                <enum name="CYA15_EN" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x419ec8" name="PRI_GPCS_TPCS_SM_SCH_TEXLOCK" variants="GK20A">
+            <bitfield low="0" high="0" name="TEX_HASH" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_SCH_TEXLOCK">
+                <enum name="TEX_HASH_DISABLE" value="0"/>
+            </bitfield>
+            <bitfield low="1" high="1" name="TEX_HASH_TILE" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_SCH_TEXLOCK">
+                <enum name="TEX_HASH_TILE_DISABLE" value="0"/>
+            </bitfield>
+            <bitfield low="2" high="2" name="TEX_HASH_PHASE" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_SCH_TEXLOCK">
+                <enum name="TEX_HASH_PHASE_DISABLE" value="0"/>
+            </bitfield>
+            <bitfield low="3" high="3" name="TEX_HASH_TEX" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_SCH_TEXLOCK">
+                <enum name="TEX_HASH_TEX_DISABLE" value="0"/>
+            </bitfield>
+            <bitfield low="4" high="11" name="TEX_HASH_TIMEOUT" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_SCH_TEXLOCK">
+                <enum name="TEX_HASH_TIMEOUT_DISABLE" value="0"/>
+            </bitfield>
+            <bitfield low="16" high="16" name="DOT_T_UNLOCK" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_SCH_TEXLOCK">
+                <enum name="DOT_T_UNLOCK_DISABLE" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x419eac" name="PRI_GPCS_TPCS_SM_SCH_MACRO_SCHED" variants="GK20A">
+            <bitfield low="2" high="2" name="LOCKBOOST_SIZE" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_SCH_MACRO_SCHED"/>
+        </reg32>
+        <reg32 offset="0x419e10" name="PRI_GPCS_TPCS_SM_DBGR_CONTROL0" variants="GK20A">
+            <bitfield low="0" high="0" name="DEBUGGER_MODE" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_DBGR_CONTROL0">
+                <enum name="DEBUGGER_MODE_ON" value="1"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="STOP_TRIGGER" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_DBGR_CONTROL0">
+                <enum name="STOP_TRIGGER_ENABLE" value="1"/>
+                <enum name="STOP_TRIGGER_DISABLE" value="0"/>
+            </bitfield>
+            <bitfield low="30" high="30" name="RUN_TRIGGER" scope="NV_PGRAPH_PRI_GPCS_TPCS_SM_DBGR_CONTROL0">
+                <enum name="RUN_TRIGGER_TASK" value="1"/>
+            </bitfield>
+        </reg32>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_ltcg.xml
+++ b/rnndb/gk20a/gk20a_ltcg.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_PLTCG">
+        <reg32 offset="0x1410c8" name="LTC0_LTS0_CBC_CTRL_1" variants="GK20A"/>
+        <reg32 offset="0x141200" name="LTC0_LTS0_DSTG_CFG0" variants="GK20A"/>
+        <reg32 offset="0x17ea00" name="LTCS_LTSS_DSTG_CFG0" variants="GK20A"/>
+        <reg32 offset="0x141104" name="LTC0_LTS0_TSTG_CFG_1" variants="GK20A">
+            <bitfield low="0" high="15" name="ACTIVE_WAYS" scope="NV_PLTCG_LTC0_LTS0_TSTG_CFG_1"/>
+            <bitfield low="16" high="17" name="ACTIVE_SETS" scope="NV_PLTCG_LTC0_LTS0_TSTG_CFG_1">
+                <enum name="ACTIVE_SETS_ALL" value="0"/>
+                <enum name="ACTIVE_SETS_HALF" value="1"/>
+                <enum name="ACTIVE_SETS_QUARTER" value="2"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x17e8c8" name="LTCS_LTSS_CBC_CTRL_1" variants="GK20A">
+            <bitfield low="0" high="0" name="CLEAN" scope="NV_PLTCG_LTCS_LTSS_CBC_CTRL_1">
+                <enum name="CLEAN_ACTIVE" value="1"/>
+            </bitfield>
+            <bitfield low="1" high="1" name="INVALIDATE" scope="NV_PLTCG_LTCS_LTSS_CBC_CTRL_1">
+                <enum name="INVALIDATE_ACTIVE" value="1"/>
+            </bitfield>
+            <bitfield low="2" high="2" name="CLEAR" scope="NV_PLTCG_LTCS_LTSS_CBC_CTRL_1">
+                <enum name="CLEAR_ACTIVE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x1410c8" name="LTC0_LTS0_CBC_CTRL_1" variants="GK20A"/>
+        <reg32 offset="0x17e8cc" name="LTCS_LTSS_CBC_CTRL_2" variants="GK20A">
+            <bitfield low="0" high="16" name="CLEAR_LOWER_BOUND" scope="NV_PLTCG_LTCS_LTSS_CBC_CTRL_2"/>
+        </reg32>
+        <reg32 offset="0x17e8d0" name="LTCS_LTSS_CBC_CTRL_3" variants="GK20A">
+            <bitfield low="0" high="16" name="CLEAR_UPPER_BOUND" scope="NV_PLTCG_LTCS_LTSS_CBC_CTRL_3">
+                <enum name="CLEAR_UPPER_BOUND_INIT" value="131071"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x17e8d4" name="LTCS_LTSS_CBC_BASE" variants="GK20A">
+            <enum name="NV_PLTCG_LTC0_LTS0_CBC_BASE_ALIGNMENT_SHIFT" value="11"/>
+            <bitfield low="0" high="25" name="ADDRESS" scope="NV_PLTCG_LTCS_LTSS_CBC_BASE"/>
+        </reg32>
+        <reg32 offset="0x17e8dc" name="LTCS_LTSS_CBC_PARAM" variants="GK20A">
+            <bitfield low="0" high="15" name="COMPTAGS_PER_CACHE_LINE" scope="NV_PLTCG_LTCS_LTSS_CBC_PARAM"/>
+            <bitfield low="24" high="27" name="CACHE_LINE_SIZE" scope="NV_PLTCG_LTCS_LTSS_CBC_PARAM"/>
+            <bitfield low="28" high="31" name="SLICES_PER_FBP" scope="NV_PLTCG_LTCS_LTSS_CBC_PARAM"/>
+        </reg32>
+        <reg32 offset="0x17e91c" name="LTCS_LTSS_TSTG_SET_MGMT_0" variants="GK20A">
+            <bitfield low="16" high="20" name="MAX_WAYS_EVICT_LAST" scope="NV_PLTCG_LTCS_LTSS_TSTG_SET_MGMT_0"/>
+        </reg32>
+        <reg32 offset="0x17ea44" name="LTCS_LTSS_DSTG_ZBC_INDEX" variants="GK20A">
+            <bitfield low="0" high="3" name="ADDRESS" scope="NV_PLTCG_LTCS_LTSS_DSTG_ZBC_INDEX"/>
+        </reg32>
+        <reg32 offset="0x17ea48" name="LTCS_LTSS_DSTG_ZBC_COLOR_CLEAR_VALUE" variants="GK20A">
+            <enum name="_SIZE_1" value="4"/>
+        </reg32>
+        <reg32 offset="0x17ea58" name="LTCS_LTSS_DSTG_ZBC_DEPTH_CLEAR_VALUE" variants="GK20A">
+            <bitfield low="0" high="31" name="FIELD" scope="NV_PLTCG_LTCS_LTSS_DSTG_ZBC_DEPTH_CLEAR_VALUE"/>
+        </reg32>
+        <reg32 offset="0x17e924" name="LTCS_LTSS_TSTG_SET_MGMT_2" variants="GK20A">
+            <bitfield low="28" high="28" name="L2_BYPASS_MODE" scope="NV_PLTCG_LTCS_LTSS_TSTG_SET_MGMT_2">
+                <enum name="L2_BYPASS_MODE_ENABLED" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x17e828" name="LTCS_LTSS_G_ELPG" variants="GK20A">
+            <bitfield low="0" high="0" name="FLUSH" scope="NV_PLTCG_LTCS_LTSS_G_ELPG">
+                <enum name="FLUSH_PENDING" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x140828" name="LTC0_LTSS_G_ELPG" variants="GK20A">
+            <bitfield low="0" high="0" name="FLUSH" scope="NV_PLTCG_LTC0_LTSS_G_ELPG">
+                <enum name="FLUSH_PENDING" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x140820" name="LTC0_LTSS_INTR" variants="GK20A"/>
+        <reg32 offset="0x17e820" name="LTCS_LTSS_INTR" variants="GK20A">
+            <bitfield low="20" high="20" name="EN_EVICTED_CB" scope="NV_PLTCG_LTCS_LTSS_INTR"/>
+        </reg32>
+        <reg32 offset="0x141020" name="LTC0_LTS0_INTR" variants="GK20A"/>
+        <reg32 offset="0x17e910" name="LTCS_LTSS_TSTG_CMGMT_0" variants="GK20A">
+            <bitfield low="0" high="0" name="INVALIDATE" scope="NV_PLTCG_LTCS_LTSS_TSTG_CMGMT_0">
+                <enum name="INVALIDATE_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="8" high="11" name="MAX_CYCLES_BETWEEN_INVALIDATES" scope="NV_PLTCG_LTCS_LTSS_TSTG_CMGMT_0">
+                <enum name="MAX_CYCLES_BETWEEN_INVALIDATES_3" value="3"/>
+            </bitfield>
+            <bitfield low="28" high="28" name="INVALIDATE_EVICT_LAST_CLASS" scope="NV_PLTCG_LTCS_LTSS_TSTG_CMGMT_0">
+                <enum name="INVALIDATE_EVICT_LAST_CLASS_TRUE" value="1"/>
+            </bitfield>
+            <bitfield low="29" high="29" name="INVALIDATE_EVICT_NORMAL_CLASS" scope="NV_PLTCG_LTCS_LTSS_TSTG_CMGMT_0">
+                <enum name="INVALIDATE_EVICT_NORMAL_CLASS_TRUE" value="1"/>
+            </bitfield>
+            <bitfield low="30" high="30" name="INVALIDATE_EVICT_FIRST_CLASS" scope="NV_PLTCG_LTCS_LTSS_TSTG_CMGMT_0">
+                <enum name="INVALIDATE_EVICT_FIRST_CLASS_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x17e914" name="LTCS_LTSS_TSTG_CMGMT_1" variants="GK20A">
+            <bitfield low="0" high="0" name="CLEAN" scope="NV_PLTCG_LTCS_LTSS_TSTG_CMGMT_1">
+                <enum name="CLEAN_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="8" high="11" name="MAX_CYCLES_BETWEEN_CLEANS" scope="NV_PLTCG_LTCS_LTSS_TSTG_CMGMT_1">
+                <enum name="MAX_CYCLES_BETWEEN_CLEANS_3" value="3"/>
+            </bitfield>
+            <bitfield low="16" high="16" name="CLEAN_WAIT_FOR_FB_TO_PULL" scope="NV_PLTCG_LTCS_LTSS_TSTG_CMGMT_1">
+                <enum name="CLEAN_WAIT_FOR_FB_TO_PULL_TRUE" value="1"/>
+            </bitfield>
+            <bitfield low="28" high="28" name="CLEAN_EVICT_LAST_CLASS" scope="NV_PLTCG_LTCS_LTSS_TSTG_CMGMT_1">
+                <enum name="CLEAN_EVICT_LAST_CLASS_TRUE" value="1"/>
+            </bitfield>
+            <bitfield low="29" high="29" name="CLEAN_EVICT_NORMAL_CLASS" scope="NV_PLTCG_LTCS_LTSS_TSTG_CMGMT_1">
+                <enum name="CLEAN_EVICT_NORMAL_CLASS_TRUE" value="1"/>
+            </bitfield>
+            <bitfield low="30" high="30" name="CLEAN_EVICT_FIRST_CLASS" scope="NV_PLTCG_LTCS_LTSS_TSTG_CMGMT_1">
+                <enum name="CLEAN_EVICT_FIRST_CLASS_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x140910" name="LTC0_LTSS_TSTG_CMGMT_0" variants="GK20A">
+            <bitfield low="0" high="0" name="INVALIDATE" scope="NV_PLTCG_LTC0_LTSS_TSTG_CMGMT_0">
+                <enum name="INVALIDATE_PENDING" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x140914" name="LTC0_LTSS_TSTG_CMGMT_1" variants="GK20A">
+            <bitfield low="0" high="0" name="CLEAN" scope="NV_PLTCG_LTC0_LTSS_TSTG_CMGMT_1">
+                <enum name="CLEAN_PENDING" value="1"/>
+            </bitfield>
+        </reg32>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_mc.xml
+++ b/rnndb/gk20a/gk20a_mc.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_PMC">
+        <reg32 offset="0x0" name="BOOT_0" variants="GK20A">
+            <bitfield low="24" high="28" name="ARCHITECTURE" scope="NV_PMC_BOOT_0"/>
+            <bitfield low="20" high="23" name="IMPLEMENTATION" scope="NV_PMC_BOOT_0"/>
+            <bitfield low="4" high="7" name="MAJOR_REVISION" scope="NV_PMC_BOOT_0"/>
+            <bitfield low="0" high="3" name="MINOR_REVISION" scope="NV_PMC_BOOT_0"/>
+        </reg32>
+        <reg32 offset="0x100" name="INTR_0" variants="GK20A">
+            <bitfield low="8" high="8" name="PFIFO" scope="NV_PMC_INTR_0">
+                <enum name="PFIFO_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="12" high="12" name="PGRAPH" scope="NV_PMC_INTR_0">
+                <enum name="PGRAPH_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="24" high="24" name="PMU" scope="NV_PMC_INTR_0">
+                <enum name="PMU_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="25" high="25" name="LTC" scope="NV_PMC_INTR_0">
+                <enum name="LTC_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="30" high="30" name="PRIV_RING" scope="NV_PMC_INTR_0">
+                <enum name="PRIV_RING_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="28" high="28" name="PBUS" scope="NV_PMC_INTR_0">
+                <enum name="PBUS_PENDING" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x104" name="INTR_1" variants="GK20A"/>
+        <reg32 offset="0x640" name="INTR_MSK_0" variants="GK20A">
+            <bitfield low="24" high="24" name="PMU" scope="NV_PMC_INTR_MSK_0">
+                <enum name="PMU_ENABLED" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x140" name="INTR_EN_0" variants="GK20A">
+            <bitfield low="0" high="1" name="INTA" scope="NV_PMC_INTR_EN_0">
+                <enum name="INTA_DISABLED" value="0"/>
+                <enum name="INTA_HARDWARE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x644" name="INTR_MSK_1" variants="GK20A">
+            <bitfield low="24" high="24" name="PMU" scope="NV_PMC_INTR_MSK_1">
+                <enum name="PMU_ENABLED" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x144" name="INTR_EN_1" variants="GK20A">
+            <bitfield low="0" high="1" name="INTA" scope="NV_PMC_INTR_EN_1">
+                <enum name="INTA_DISABLED" value="0"/>
+                <enum name="INTA_HARDWARE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x200" name="ENABLE" variants="GK20A">
+            <bitfield low="2" high="2" name="XBAR" scope="NV_PMC_ENABLE">
+                <enum name="XBAR_ENABLED" value="1"/>
+            </bitfield>
+            <bitfield low="3" high="3" name="L2" scope="NV_PMC_ENABLE">
+                <enum name="L2_ENABLED" value="1"/>
+            </bitfield>
+            <bitfield low="4" high="4" name="PMEDIA" scope="NV_PMC_ENABLE"/>
+            <bitfield low="5" high="5" name="PRIV_RING" scope="NV_PMC_ENABLE">
+                <enum name="PRIV_RING_ENABLED" value="1"/>
+            </bitfield>
+            <bitfield low="6" high="6" name="CE0" scope="NV_PMC_ENABLE"/>
+            <bitfield low="8" high="8" name="PFIFO" scope="NV_PMC_ENABLE">
+                <enum name="PFIFO_ENABLED" value="1"/>
+            </bitfield>
+            <bitfield low="12" high="12" name="PGRAPH" scope="NV_PMC_ENABLE">
+                <enum name="PGRAPH_ENABLED" value="1"/>
+            </bitfield>
+            <bitfield low="13" high="13" name="PWR" scope="NV_PMC_ENABLE">
+                <enum name="PWR_DISABLED" value="0"/>
+                <enum name="PWR_ENABLED" value="1"/>
+            </bitfield>
+            <bitfield low="20" high="20" name="PFB" scope="NV_PMC_ENABLE">
+                <enum name="PFB_ENABLED" value="1"/>
+            </bitfield>
+            <bitfield low="21" high="21" name="CE2" scope="NV_PMC_ENABLE">
+                <enum name="CE2_ENABLED" value="1"/>
+            </bitfield>
+            <bitfield low="27" high="27" name="BLG" scope="NV_PMC_ENABLE">
+                <enum name="BLG_ENABLED" value="1"/>
+            </bitfield>
+            <bitfield low="28" high="28" name="PERFMON" scope="NV_PMC_ENABLE">
+                <enum name="PERFMON_ENABLED" value="1"/>
+            </bitfield>
+            <bitfield low="29" high="29" name="HUB" scope="NV_PMC_ENABLE">
+                <enum name="HUB_ENABLED" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x204" name="ENABLE_PB" variants="GK20A">
+            <bitfield low="0" high="0" name="0" scope="NV_PMC_ENABLE_PB">
+                <enum name="0_ENABLED" value="1"/>
+            </bitfield>
+            <bitfield low="0" high="0" name="SEL" scope="NV_PMC_ENABLE_PB"/>
+        </reg32>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_mmu.xml
+++ b/rnndb/gk20a/gk20a_mmu.xml
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_MMU">
+        <reg32 offset="0xffffffff" name="PDE" variants="GK20A">
+            <bitfield low="0" high="1" name="APERTURE_BIG" scope="NV_MMU_PDE">
+                <enum name="APERTURE_BIG_INVALID" value="0"/>
+                <enum name="APERTURE_BIG_VIDEO_MEMORY" value="1"/>
+            </bitfield>
+            <bitfield low="2" high="3" name="SIZE" scope="NV_MMU_PDE">
+                <enum name="SIZE_FULL" value="0"/>
+            </bitfield>
+            <bitfield low="4" high="31" name="ADDRESS_BIG_SYS" scope="NV_MMU_PDE"/>
+            <bitfield low="32" high="33" name="APERTURE_SMALL" scope="NV_MMU_PDE">
+                <enum name="APERTURE_SMALL_INVALID" value="0"/>
+                <enum name="APERTURE_SMALL_VIDEO_MEMORY" value="1"/>
+            </bitfield>
+            <bitfield low="34" high="34" name="VOL_SMALL" scope="NV_MMU_PDE">
+                <enum name="VOL_SMALL_TRUE" value="1"/>
+                <enum name="VOL_SMALL_FALSE" value="0"/>
+            </bitfield>
+            <bitfield low="35" high="35" name="VOL_BIG" scope="NV_MMU_PDE">
+                <enum name="VOL_BIG_TRUE" value="1"/>
+                <enum name="VOL_BIG_FALSE" value="0"/>
+            </bitfield>
+            <bitfield low="36" high="63" name="ADDRESS_SMALL_SYS" scope="NV_MMU_PDE"/>
+            <enum name="ADDRESS_SHIFT" value="12"/>
+            <enum name="_SIZE" value="8"/>
+        </reg32>
+        <reg32 offset="0xffffffff" name="PTE" variants="GK20A">
+            <enum name="_SIZE" value="8"/>
+            <bitfield low="0" high="0" name="VALID" scope="NV_MMU_PTE">
+                <enum name="VALID_TRUE" value="1"/>
+                <enum name="VALID_FALSE" value="0"/>
+            </bitfield>
+            <bitfield low="4" high="31" name="ADDRESS_SYS" scope="NV_MMU_PTE"/>
+            <bitfield low="32" high="32" name="VOL" scope="NV_MMU_PTE">
+                <enum name="VOL_TRUE" value="1"/>
+                <enum name="VOL_FALSE" value="0"/>
+            </bitfield>
+            <bitfield low="33" high="34" name="APERTURE" scope="NV_MMU_PTE">
+                <enum name="APERTURE_VIDEO_MEMORY" value="0"/>
+            </bitfield>
+            <bitfield low="2" high="2" name="READ_ONLY" scope="NV_MMU_PTE">
+                <enum name="READ_ONLY_TRUE" value="1"/>
+            </bitfield>
+            <bitfield low="63" high="63" name="WRITE_DISABLE" scope="NV_MMU_PTE">
+                <enum name="WRITE_DISABLE_TRUE" value="1"/>
+            </bitfield>
+            <bitfield low="62" high="62" name="READ_DISABLE" scope="NV_MMU_PTE">
+                <enum name="READ_DISABLE_TRUE" value="1"/>
+            </bitfield>
+            <bitfield low="44" high="60" name="COMPTAGLINE" scope="NV_MMU_PTE"/>
+            <enum name="ADDRESS_SHIFT" value="12"/>
+            <bitfield low="36" high="43" name="KIND" scope="NV_MMU_PTE">
+                <enum name="KIND_INVALID" value="255"/>
+                <enum name="KIND_PITCH" value="0"/>
+                <enum name="KIND_Z16" value="1"/>
+                <enum name="KIND_Z16_2C" value="2"/>
+                <enum name="KIND_Z16_MS2_2C" value="3"/>
+                <enum name="KIND_Z16_MS4_2C" value="4"/>
+                <enum name="KIND_Z16_MS8_2C" value="5"/>
+                <enum name="KIND_Z16_MS16_2C" value="6"/>
+                <enum name="KIND_Z16_2Z" value="7"/>
+                <enum name="KIND_Z16_MS2_2Z" value="8"/>
+                <enum name="KIND_Z16_MS4_2Z" value="9"/>
+                <enum name="KIND_Z16_MS8_2Z" value="10"/>
+                <enum name="KIND_Z16_MS16_2Z" value="11"/>
+                <enum name="KIND_Z16_4CZ" value="12"/>
+                <enum name="KIND_Z16_MS2_4CZ" value="13"/>
+                <enum name="KIND_Z16_MS4_4CZ" value="14"/>
+                <enum name="KIND_Z16_MS8_4CZ" value="15"/>
+                <enum name="KIND_Z16_MS16_4CZ" value="16"/>
+                <enum name="KIND_S8Z24" value="17"/>
+                <enum name="KIND_S8Z24_1Z" value="18"/>
+                <enum name="KIND_S8Z24_MS2_1Z" value="19"/>
+                <enum name="KIND_S8Z24_MS4_1Z" value="20"/>
+                <enum name="KIND_S8Z24_MS8_1Z" value="21"/>
+                <enum name="KIND_S8Z24_MS16_1Z" value="22"/>
+                <enum name="KIND_S8Z24_2CZ" value="23"/>
+                <enum name="KIND_S8Z24_MS2_2CZ" value="24"/>
+                <enum name="KIND_S8Z24_MS4_2CZ" value="25"/>
+                <enum name="KIND_S8Z24_MS8_2CZ" value="26"/>
+                <enum name="KIND_S8Z24_MS16_2CZ" value="27"/>
+                <enum name="KIND_S8Z24_2CS" value="28"/>
+                <enum name="KIND_S8Z24_MS2_2CS" value="29"/>
+                <enum name="KIND_S8Z24_MS4_2CS" value="30"/>
+                <enum name="KIND_S8Z24_MS8_2CS" value="31"/>
+                <enum name="KIND_S8Z24_MS16_2CS" value="32"/>
+                <enum name="KIND_S8Z24_4CSZV" value="33"/>
+                <enum name="KIND_S8Z24_MS2_4CSZV" value="34"/>
+                <enum name="KIND_S8Z24_MS4_4CSZV" value="35"/>
+                <enum name="KIND_S8Z24_MS8_4CSZV" value="36"/>
+                <enum name="KIND_S8Z24_MS16_4CSZV" value="37"/>
+                <enum name="KIND_V8Z24_MS4_VC12" value="38"/>
+                <enum name="KIND_V8Z24_MS4_VC4" value="39"/>
+                <enum name="KIND_V8Z24_MS8_VC8" value="40"/>
+                <enum name="KIND_V8Z24_MS8_VC24" value="41"/>
+                <enum name="KIND_V8Z24_MS4_VC12_1ZV" value="46"/>
+                <enum name="KIND_V8Z24_MS4_VC4_1ZV" value="47"/>
+                <enum name="KIND_V8Z24_MS8_VC8_1ZV" value="48"/>
+                <enum name="KIND_V8Z24_MS8_VC24_1ZV" value="49"/>
+                <enum name="KIND_V8Z24_MS4_VC12_2CS" value="50"/>
+                <enum name="KIND_V8Z24_MS4_VC4_2CS" value="51"/>
+                <enum name="KIND_V8Z24_MS8_VC8_2CS" value="52"/>
+                <enum name="KIND_V8Z24_MS8_VC24_2CS" value="53"/>
+                <enum name="KIND_V8Z24_MS4_VC12_2CZV" value="58"/>
+                <enum name="KIND_V8Z24_MS4_VC4_2CZV" value="59"/>
+                <enum name="KIND_V8Z24_MS8_VC8_2CZV" value="60"/>
+                <enum name="KIND_V8Z24_MS8_VC24_2CZV" value="61"/>
+                <enum name="KIND_V8Z24_MS4_VC12_2ZV" value="62"/>
+                <enum name="KIND_V8Z24_MS4_VC4_2ZV" value="63"/>
+                <enum name="KIND_V8Z24_MS8_VC8_2ZV" value="64"/>
+                <enum name="KIND_V8Z24_MS8_VC24_2ZV" value="65"/>
+                <enum name="KIND_V8Z24_MS4_VC12_4CSZV" value="66"/>
+                <enum name="KIND_V8Z24_MS4_VC4_4CSZV" value="67"/>
+                <enum name="KIND_V8Z24_MS8_VC8_4CSZV" value="68"/>
+                <enum name="KIND_V8Z24_MS8_VC24_4CSZV" value="69"/>
+                <enum name="KIND_Z24S8" value="70"/>
+                <enum name="KIND_Z24S8_1Z" value="71"/>
+                <enum name="KIND_Z24S8_MS2_1Z" value="72"/>
+                <enum name="KIND_Z24S8_MS4_1Z" value="73"/>
+                <enum name="KIND_Z24S8_MS8_1Z" value="74"/>
+                <enum name="KIND_Z24S8_MS16_1Z" value="75"/>
+                <enum name="KIND_Z24S8_2CS" value="76"/>
+                <enum name="KIND_Z24S8_MS2_2CS" value="77"/>
+                <enum name="KIND_Z24S8_MS4_2CS" value="78"/>
+                <enum name="KIND_Z24S8_MS8_2CS" value="79"/>
+                <enum name="KIND_Z24S8_MS16_2CS" value="80"/>
+                <enum name="KIND_Z24S8_2CZ" value="81"/>
+                <enum name="KIND_Z24S8_MS2_2CZ" value="82"/>
+                <enum name="KIND_Z24S8_MS4_2CZ" value="83"/>
+                <enum name="KIND_Z24S8_MS8_2CZ" value="84"/>
+                <enum name="KIND_Z24S8_MS16_2CZ" value="85"/>
+                <enum name="KIND_Z24S8_4CSZV" value="86"/>
+                <enum name="KIND_Z24S8_MS2_4CSZV" value="87"/>
+                <enum name="KIND_Z24S8_MS4_4CSZV" value="88"/>
+                <enum name="KIND_Z24S8_MS8_4CSZV" value="89"/>
+                <enum name="KIND_Z24S8_MS16_4CSZV" value="90"/>
+                <enum name="KIND_Z24V8_MS4_VC12" value="91"/>
+                <enum name="KIND_Z24V8_MS4_VC4" value="92"/>
+                <enum name="KIND_Z24V8_MS8_VC8" value="93"/>
+                <enum name="KIND_Z24V8_MS8_VC24" value="94"/>
+                <enum name="KIND_Z24V8_MS4_VC12_1ZV" value="99"/>
+                <enum name="KIND_Z24V8_MS4_VC4_1ZV" value="100"/>
+                <enum name="KIND_Z24V8_MS8_VC8_1ZV" value="101"/>
+                <enum name="KIND_Z24V8_MS8_VC24_1ZV" value="102"/>
+                <enum name="KIND_Z24V8_MS4_VC12_2CS" value="103"/>
+                <enum name="KIND_Z24V8_MS4_VC4_2CS" value="104"/>
+                <enum name="KIND_Z24V8_MS8_VC8_2CS" value="105"/>
+                <enum name="KIND_Z24V8_MS8_VC24_2CS" value="106"/>
+                <enum name="KIND_Z24V8_MS4_VC12_2CZV" value="111"/>
+                <enum name="KIND_Z24V8_MS4_VC4_2CZV" value="112"/>
+                <enum name="KIND_Z24V8_MS8_VC8_2CZV" value="113"/>
+                <enum name="KIND_Z24V8_MS8_VC24_2CZV" value="114"/>
+                <enum name="KIND_Z24V8_MS4_VC12_2ZV" value="115"/>
+                <enum name="KIND_Z24V8_MS4_VC4_2ZV" value="116"/>
+                <enum name="KIND_Z24V8_MS8_VC8_2ZV" value="117"/>
+                <enum name="KIND_Z24V8_MS8_VC24_2ZV" value="118"/>
+                <enum name="KIND_Z24V8_MS4_VC12_4CSZV" value="119"/>
+                <enum name="KIND_Z24V8_MS4_VC4_4CSZV" value="120"/>
+                <enum name="KIND_Z24V8_MS8_VC8_4CSZV" value="121"/>
+                <enum name="KIND_Z24V8_MS8_VC24_4CSZV" value="122"/>
+                <enum name="KIND_ZF32" value="123"/>
+                <enum name="KIND_ZF32_1Z" value="124"/>
+                <enum name="KIND_ZF32_MS2_1Z" value="125"/>
+                <enum name="KIND_ZF32_MS4_1Z" value="126"/>
+                <enum name="KIND_ZF32_MS8_1Z" value="127"/>
+                <enum name="KIND_ZF32_MS16_1Z" value="128"/>
+                <enum name="KIND_ZF32_2CS" value="129"/>
+                <enum name="KIND_ZF32_MS2_2CS" value="130"/>
+                <enum name="KIND_ZF32_MS4_2CS" value="131"/>
+                <enum name="KIND_ZF32_MS8_2CS" value="132"/>
+                <enum name="KIND_ZF32_MS16_2CS" value="133"/>
+                <enum name="KIND_ZF32_2CZ" value="134"/>
+                <enum name="KIND_ZF32_MS2_2CZ" value="135"/>
+                <enum name="KIND_ZF32_MS4_2CZ" value="136"/>
+                <enum name="KIND_ZF32_MS8_2CZ" value="137"/>
+                <enum name="KIND_ZF32_MS16_2CZ" value="138"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS4_VC12" value="139"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS4_VC4" value="140"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS8_VC8" value="141"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS8_VC24" value="142"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS4_VC12_1CS" value="143"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS4_VC4_1CS" value="144"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS8_VC8_1CS" value="145"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS8_VC24_1CS" value="146"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS4_VC12_1ZV" value="151"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS4_VC4_1ZV" value="152"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS8_VC8_1ZV" value="153"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS8_VC24_1ZV" value="154"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS4_VC12_1CZV" value="155"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS4_VC4_1CZV" value="156"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS8_VC8_1CZV" value="157"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS8_VC24_1CZV" value="158"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS4_VC12_2CS" value="159"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS4_VC4_2CS" value="160"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS8_VC8_2CS" value="161"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS8_VC24_2CS" value="162"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS4_VC12_2CSZV" value="163"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS4_VC4_2CSZV" value="164"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS8_VC8_2CSZV" value="165"/>
+                <enum name="KIND_X8Z24_X16V8S8_MS8_VC24_2CSZV" value="166"/>
+                <enum name="KIND_ZF32_X16V8S8_MS4_VC12" value="167"/>
+                <enum name="KIND_ZF32_X16V8S8_MS4_VC4" value="168"/>
+                <enum name="KIND_ZF32_X16V8S8_MS8_VC8" value="169"/>
+                <enum name="KIND_ZF32_X16V8S8_MS8_VC24" value="170"/>
+                <enum name="KIND_ZF32_X16V8S8_MS4_VC12_1CS" value="171"/>
+                <enum name="KIND_ZF32_X16V8S8_MS4_VC4_1CS" value="172"/>
+                <enum name="KIND_ZF32_X16V8S8_MS8_VC8_1CS" value="173"/>
+                <enum name="KIND_ZF32_X16V8S8_MS8_VC24_1CS" value="174"/>
+                <enum name="KIND_ZF32_X16V8S8_MS4_VC12_1ZV" value="179"/>
+                <enum name="KIND_ZF32_X16V8S8_MS4_VC4_1ZV" value="180"/>
+                <enum name="KIND_ZF32_X16V8S8_MS8_VC8_1ZV" value="181"/>
+                <enum name="KIND_ZF32_X16V8S8_MS8_VC24_1ZV" value="182"/>
+                <enum name="KIND_ZF32_X16V8S8_MS4_VC12_1CZV" value="183"/>
+                <enum name="KIND_ZF32_X16V8S8_MS4_VC4_1CZV" value="184"/>
+                <enum name="KIND_ZF32_X16V8S8_MS8_VC8_1CZV" value="185"/>
+                <enum name="KIND_ZF32_X16V8S8_MS8_VC24_1CZV" value="186"/>
+                <enum name="KIND_ZF32_X16V8S8_MS4_VC12_2CS" value="187"/>
+                <enum name="KIND_ZF32_X16V8S8_MS4_VC4_2CS" value="188"/>
+                <enum name="KIND_ZF32_X16V8S8_MS8_VC8_2CS" value="189"/>
+                <enum name="KIND_ZF32_X16V8S8_MS8_VC24_2CS" value="190"/>
+                <enum name="KIND_ZF32_X16V8S8_MS4_VC12_2CSZV" value="191"/>
+                <enum name="KIND_ZF32_X16V8S8_MS4_VC4_2CSZV" value="192"/>
+                <enum name="KIND_ZF32_X16V8S8_MS8_VC8_2CSZV" value="193"/>
+                <enum name="KIND_ZF32_X16V8S8_MS8_VC24_2CSZV" value="194"/>
+                <enum name="KIND_ZF32_X24S8" value="195"/>
+                <enum name="KIND_ZF32_X24S8_1CS" value="196"/>
+                <enum name="KIND_ZF32_X24S8_MS2_1CS" value="197"/>
+                <enum name="KIND_ZF32_X24S8_MS4_1CS" value="198"/>
+                <enum name="KIND_ZF32_X24S8_MS8_1CS" value="199"/>
+                <enum name="KIND_ZF32_X24S8_MS16_1CS" value="200"/>
+                <enum name="KIND_ZF32_X24S8_2CSZV" value="206"/>
+                <enum name="KIND_ZF32_X24S8_MS2_2CSZV" value="207"/>
+                <enum name="KIND_ZF32_X24S8_MS4_2CSZV" value="208"/>
+                <enum name="KIND_ZF32_X24S8_MS8_2CSZV" value="209"/>
+                <enum name="KIND_ZF32_X24S8_MS16_2CSZV" value="210"/>
+                <enum name="KIND_ZF32_X24S8_2CS" value="211"/>
+                <enum name="KIND_ZF32_X24S8_MS2_2CS" value="212"/>
+                <enum name="KIND_ZF32_X24S8_MS4_2CS" value="213"/>
+                <enum name="KIND_ZF32_X24S8_MS8_2CS" value="214"/>
+                <enum name="KIND_ZF32_X24S8_MS16_2CS" value="215"/>
+                <enum name="KIND_GENERIC_16BX2" value="254"/>
+                <enum name="KIND_C32_2C" value="216"/>
+                <enum name="KIND_C32_2CBR" value="217"/>
+                <enum name="KIND_C32_2CBA" value="218"/>
+                <enum name="KIND_C32_2CRA" value="219"/>
+                <enum name="KIND_C32_2BRA" value="220"/>
+                <enum name="KIND_C32_MS2_2C" value="221"/>
+                <enum name="KIND_C32_MS2_2CBR" value="222"/>
+                <enum name="KIND_C32_MS2_2CRA" value="204"/>
+                <enum name="KIND_C32_MS4_2C" value="223"/>
+                <enum name="KIND_C32_MS4_2CBR" value="224"/>
+                <enum name="KIND_C32_MS4_2CBA" value="225"/>
+                <enum name="KIND_C32_MS4_2CRA" value="226"/>
+                <enum name="KIND_C32_MS4_2BRA" value="227"/>
+                <enum name="KIND_C32_MS8_MS16_2C" value="228"/>
+                <enum name="KIND_C32_MS8_MS16_2CRA" value="229"/>
+                <enum name="KIND_C64_2C" value="230"/>
+                <enum name="KIND_C64_2CBR" value="231"/>
+                <enum name="KIND_C64_2CBA" value="232"/>
+                <enum name="KIND_C64_2CRA" value="233"/>
+                <enum name="KIND_C64_2BRA" value="234"/>
+                <enum name="KIND_C64_MS2_2C" value="235"/>
+                <enum name="KIND_C64_MS2_2CBR" value="236"/>
+                <enum name="KIND_C64_MS2_2CRA" value="205"/>
+                <enum name="KIND_C64_MS4_2C" value="237"/>
+                <enum name="KIND_C64_MS4_2CBR" value="238"/>
+                <enum name="KIND_C64_MS4_2CBA" value="239"/>
+                <enum name="KIND_C64_MS4_2CRA" value="240"/>
+                <enum name="KIND_C64_MS4_2BRA" value="241"/>
+                <enum name="KIND_C64_MS8_MS16_2C" value="242"/>
+                <enum name="KIND_C64_MS8_MS16_2CRA" value="243"/>
+                <enum name="KIND_C128_2C" value="244"/>
+                <enum name="KIND_C128_2CR" value="245"/>
+                <enum name="KIND_C128_MS2_2C" value="246"/>
+                <enum name="KIND_C128_MS2_2CR" value="247"/>
+                <enum name="KIND_C128_MS4_2C" value="248"/>
+                <enum name="KIND_C128_MS4_2CR" value="249"/>
+                <enum name="KIND_C128_MS8_MS16_2C" value="250"/>
+                <enum name="KIND_C128_MS8_MS16_2CR" value="251"/>
+                <enum name="KIND_X8C24" value="252"/>
+                <enum name="KIND_PITCH_NO_SWIZZLE" value="253"/>
+                <enum name="KIND_SMSKED_MESSAGE" value="202"/>
+                <enum name="KIND_SMHOST_MESSAGE" value="203"/>
+            </bitfield>
+        </reg32>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_pbdma.xml
+++ b/rnndb/gk20a/gk20a_pbdma.xml
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_PBDMA">
+        <reg32 offset="0x10000004" name="NV_PPBDMA_GP_ENTRY1" variants="GK20A">
+            <bitfield low="0" high="7" name="GET_HI" scope="NV_PPBDMA_GP_ENTRY1"/>
+            <bitfield low="10" high="30" name="LENGTH" scope="NV_PPBDMA_GP_ENTRY1"/>
+        </reg32>
+        <reg32 offset="0x40048" name="NV_PPBDMA_GP_BASE" variants="GK20A">
+            <enum name="_SIZE_1" value="1"/>
+            <bitfield low="3" high="31" name="OFFSET" scope="NV_PPBDMA_GP_BASE"/>
+            <bitfield low="0" high="2" name="RSVD" scope="NV_PPBDMA_GP_BASE"/>
+        </reg32>
+        <reg32 offset="0x4004c" name="NV_PPBDMA_GP_BASE_HI" variants="GK20A">
+            <bitfield low="0" high="7" name="OFFSET" scope="NV_PPBDMA_GP_BASE_HI"/>
+            <bitfield low="16" high="20" name="LIMIT2" scope="NV_PPBDMA_GP_BASE_HI"/>
+        </reg32>
+        <reg32 offset="0x40050" name="NV_PPBDMA_GP_FETCH" variants="GK20A"/>
+        <reg32 offset="0x40014" name="NV_PPBDMA_GP_GET" variants="GK20A"/>
+        <reg32 offset="0x40000" name="NV_PPBDMA_GP_PUT" variants="GK20A"/>
+        <reg32 offset="0x4012c" name="NV_PPBDMA_TIMEOUT" variants="GK20A">
+            <enum name="_SIZE_1" value="1"/>
+            <bitfield low="0" high="31" name="PERIOD" scope="NV_PPBDMA_TIMEOUT">
+                <enum name="PERIOD_MAX" value="4294967295"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x40054" name="NV_PPBDMA_PB_FETCH" variants="GK20A"/>
+        <reg32 offset="0x40058" name="NV_PPBDMA_PB_FETCH_HI" variants="GK20A"/>
+        <reg32 offset="0x40018" name="NV_PPBDMA_GET" variants="GK20A"/>
+        <reg32 offset="0x4001c" name="NV_PPBDMA_GET_HI" variants="GK20A"/>
+        <reg32 offset="0x4005c" name="NV_PPBDMA_PUT" variants="GK20A"/>
+        <reg32 offset="0x40060" name="NV_PPBDMA_PUT_HI" variants="GK20A"/>
+        <reg32 offset="0x4009c" name="NV_PPBDMA_FORMATS" variants="GK20A">
+            <bitfield low="0" high="1" name="GP" scope="NV_PPBDMA_FORMATS">
+                <enum name="GP_FERMI0" value="0"/>
+            </bitfield>
+            <bitfield low="8" high="9" name="PB" scope="NV_PPBDMA_FORMATS">
+                <enum name="PB_FERMI1" value="1"/>
+            </bitfield>
+            <bitfield low="24" high="25" name="MP" scope="NV_PPBDMA_FORMATS">
+                <enum name="MP_FERMI0" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x40084" name="NV_PPBDMA_PB_HEADER" variants="GK20A">
+            <bitfield low="1" high="1" name="PRIV" scope="NV_PPBDMA_PB_HEADER">
+                <enum name="PRIV_USER" value="0"/>
+            </bitfield>
+            <bitfield low="2" high="13" name="METHOD" scope="NV_PPBDMA_PB_HEADER">
+                <enum name="METHOD_ZERO" value="0"/>
+            </bitfield>
+            <bitfield low="16" high="18" name="SUBCHANNEL" scope="NV_PPBDMA_PB_HEADER">
+                <enum name="SUBCHANNEL_ZERO" value="0"/>
+            </bitfield>
+            <bitfield low="20" high="20" name="LEVEL" scope="NV_PPBDMA_PB_HEADER">
+                <enum name="LEVEL_MAIN" value="0"/>
+            </bitfield>
+            <bitfield low="22" high="22" name="FIRST" scope="NV_PPBDMA_PB_HEADER">
+                <enum name="FIRST_TRUE" value="1"/>
+            </bitfield>
+            <bitfield low="29" high="31" name="TYPE" scope="NV_PPBDMA_PB_HEADER">
+                <enum name="TYPE_INC" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x40118" name="NV_PPBDMA_HDR_SHADOW" variants="GK20A"/>
+        <reg32 offset="0x40094" name="NV_PPBDMA_SUBDEVICE" variants="GK20A">
+            <bitfield low="0" high="11" name="ID" scope="NV_PPBDMA_SUBDEVICE"/>
+            <bitfield low="28" high="28" name="STATUS" scope="NV_PPBDMA_SUBDEVICE">
+                <enum name="STATUS_ACTIVE" value="1"/>
+            </bitfield>
+            <bitfield low="29" high="29" name="CHANNEL_DMA" scope="NV_PPBDMA_SUBDEVICE">
+                <enum name="CHANNEL_DMA_ENABLE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x400c0" name="NV_PPBDMA_METHOD0" variants="GK20A"/>
+        <reg32 offset="0x400c4" name="NV_PPBDMA_DATA0" variants="GK20A"/>
+        <reg32 offset="0x400ac" name="NV_PPBDMA_TARGET" variants="GK20A">
+            <bitfield low="0" high="4" name="ENGINE" scope="NV_PPBDMA_TARGET">
+                <enum name="ENGINE_SW" value="31"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x40030" name="NV_PPBDMA_ACQUIRE" variants="GK20A">
+            <bitfield low="0" high="6" name="RETRY_MAN" scope="NV_PPBDMA_ACQUIRE">
+                <enum name="RETRY_MAN_2" value="2"/>
+            </bitfield>
+            <bitfield low="7" high="10" name="RETRY_EXP" scope="NV_PPBDMA_ACQUIRE">
+                <enum name="RETRY_EXP_2" value="2"/>
+            </bitfield>
+            <bitfield low="11" high="14" name="TIMEOUT_EXP" scope="NV_PPBDMA_ACQUIRE">
+                <enum name="TIMEOUT_EXP_MAX" value="15"/>
+            </bitfield>
+            <bitfield low="15" high="30" name="TIMEOUT_MAN" scope="NV_PPBDMA_ACQUIRE">
+                <enum name="TIMEOUT_MAN_MAX" value="65535"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="TIMEOUT_EN" scope="NV_PPBDMA_ACQUIRE">
+                <enum name="TIMEOUT_EN_DISABLE" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x40100" name="NV_PPBDMA_STATUS" variants="GK20A"/>
+        <reg32 offset="0x40120" name="NV_PPBDMA_CHANNEL" variants="GK20A"/>
+        <reg32 offset="0x40010" name="NV_PPBDMA_SIGNATURE" variants="GK20A">
+            <bitfield low="0" high="15" name="HW" scope="NV_PPBDMA_SIGNATURE">
+                <enum name="HW_VALID" value="64206"/>
+            </bitfield>
+            <bitfield low="16" high="31" name="SW" scope="NV_PPBDMA_SIGNATURE">
+                <enum name="SW_ZERO" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x40008" name="NV_PPBDMA_USERD" variants="GK20A">
+            <bitfield low="0" high="1" name="TARGET" scope="NV_PPBDMA_USERD">
+                <enum name="TARGET_VID_MEM" value="0"/>
+            </bitfield>
+            <bitfield low="9" high="31" name="ADDR" scope="NV_PPBDMA_USERD"/>
+        </reg32>
+        <reg32 offset="0x4000c" name="NV_PPBDMA_USERD_HI" variants="GK20A">
+            <bitfield low="0" high="7" name="ADDR" scope="NV_PPBDMA_USERD_HI"/>
+        </reg32>
+        <reg32 offset="0x400e4" name="NV_PPBDMA_HCE_CTRL" variants="GK20A">
+            <bitfield low="5" high="5" name="HCE_PRIV_MODE" scope="NV_PPBDMA_HCE_CTRL">
+                <enum name="HCE_PRIV_MODE_YES" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x40108" name="NV_PPBDMA_INTR_0" variants="GK20A">
+            <bitfield low="0" high="0" name="MEMREQ" scope="NV_PPBDMA_INTR_0">
+                <enum name="MEMREQ_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="1" high="1" name="MEMACK_TIMEOUT" scope="NV_PPBDMA_INTR_0">
+                <enum name="MEMACK_TIMEOUT_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="2" high="2" name="MEMACK_EXTRA" scope="NV_PPBDMA_INTR_0">
+                <enum name="MEMACK_EXTRA_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="3" high="3" name="MEMDAT_TIMEOUT" scope="NV_PPBDMA_INTR_0">
+                <enum name="MEMDAT_TIMEOUT_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="4" high="4" name="MEMDAT_EXTRA" scope="NV_PPBDMA_INTR_0">
+                <enum name="MEMDAT_EXTRA_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="5" high="5" name="MEMFLUSH" scope="NV_PPBDMA_INTR_0">
+                <enum name="MEMFLUSH_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="6" high="6" name="MEMOP" scope="NV_PPBDMA_INTR_0">
+                <enum name="MEMOP_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="7" high="7" name="LBCONNECT" scope="NV_PPBDMA_INTR_0">
+                <enum name="LBCONNECT_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="8" high="8" name="LBREQ" scope="NV_PPBDMA_INTR_0">
+                <enum name="LBREQ_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="9" high="9" name="LBACK_TIMEOUT" scope="NV_PPBDMA_INTR_0">
+                <enum name="LBACK_TIMEOUT_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="10" high="10" name="LBACK_EXTRA" scope="NV_PPBDMA_INTR_0">
+                <enum name="LBACK_EXTRA_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="11" high="11" name="LBDAT_TIMEOUT" scope="NV_PPBDMA_INTR_0">
+                <enum name="LBDAT_TIMEOUT_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="12" high="12" name="LBDAT_EXTRA" scope="NV_PPBDMA_INTR_0">
+                <enum name="LBDAT_EXTRA_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="13" high="13" name="GPFIFO" scope="NV_PPBDMA_INTR_0">
+                <enum name="GPFIFO_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="14" high="14" name="GPPTR" scope="NV_PPBDMA_INTR_0">
+                <enum name="GPPTR_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="15" high="15" name="GPENTRY" scope="NV_PPBDMA_INTR_0">
+                <enum name="GPENTRY_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="16" high="16" name="GPCRC" scope="NV_PPBDMA_INTR_0">
+                <enum name="GPCRC_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="17" high="17" name="PBPTR" scope="NV_PPBDMA_INTR_0">
+                <enum name="PBPTR_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="18" high="18" name="PBENTRY" scope="NV_PPBDMA_INTR_0">
+                <enum name="PBENTRY_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="19" high="19" name="PBCRC" scope="NV_PPBDMA_INTR_0">
+                <enum name="PBCRC_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="20" high="20" name="XBARCONNECT" scope="NV_PPBDMA_INTR_0">
+                <enum name="XBARCONNECT_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="21" high="21" name="METHOD" scope="NV_PPBDMA_INTR_0">
+                <enum name="METHOD_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="22" high="22" name="METHODCRC" scope="NV_PPBDMA_INTR_0">
+                <enum name="METHODCRC_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="23" high="23" name="DEVICE" scope="NV_PPBDMA_INTR_0">
+                <enum name="DEVICE_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="25" high="25" name="SEMAPHORE" scope="NV_PPBDMA_INTR_0">
+                <enum name="SEMAPHORE_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="26" high="26" name="ACQUIRE" scope="NV_PPBDMA_INTR_0">
+                <enum name="ACQUIRE_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="27" high="27" name="PRI" scope="NV_PPBDMA_INTR_0">
+                <enum name="PRI_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="29" high="29" name="NO_CTXSW_SEG" scope="NV_PPBDMA_INTR_0">
+                <enum name="NO_CTXSW_SEG_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="30" high="30" name="PBSEG" scope="NV_PPBDMA_INTR_0">
+                <enum name="PBSEG_PENDING" value="1"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="SIGNATURE" scope="NV_PPBDMA_INTR_0">
+                <enum name="SIGNATURE_PENDING" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x40148" name="NV_PPBDMA_INTR_1" variants="GK20A"/>
+        <reg32 offset="0x4010c" name="NV_PPBDMA_INTR_EN_0" variants="GK20A">
+            <bitfield low="8" high="8" name="LBREQ" scope="NV_PPBDMA_INTR_EN_0">
+                <enum name="LBREQ_ENABLED" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x4014c" name="NV_PPBDMA_INTR_EN_1" variants="GK20A"/>
+        <reg32 offset="0x4013c" name="NV_PPBDMA_INTR_STALL" variants="GK20A">
+            <bitfield low="8" high="8" name="LBREQ" scope="NV_PPBDMA_INTR_STALL">
+                <enum name="LBREQ_ENABLED" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x8" name="NV_UDMA_NOP" variants="GK20A"/>
+        <reg32 offset="0x400a4" name="NV_PPBDMA_SYNCPOINTA" variants="GK20A">
+            <bitfield low="0" high="31" name="PAYLOAD" scope="NV_PPBDMA_SYNCPOINTA"/>
+        </reg32>
+        <reg32 offset="0x400a8" name="NV_PPBDMA_SYNCPOINTB" variants="GK20A">
+            <bitfield low="0" high="1" name="OPERATION" scope="NV_PPBDMA_SYNCPOINTB">
+                <enum name="OPERATION_WAIT" value="0"/>
+            </bitfield>
+            <bitfield low="4" high="4" name="WAIT_SWITCH" scope="NV_PPBDMA_SYNCPOINTB">
+                <enum name="WAIT_SWITCH_EN" value="1"/>
+            </bitfield>
+            <bitfield low="8" high="15" name="SYNCPT_INDEX" scope="NV_PPBDMA_SYNCPOINTB"/>
+        </reg32>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_priv_master.xml
+++ b/rnndb/gk20a/gk20a_priv_master.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_PPRIV_MASTER">
+        <reg32 offset="0x12004c" name="RING_COMMAND" variants="GK20A">
+            <bitfield low="0" high="5" name="CMD" scope="NV_PPRIV_MASTER_RING_COMMAND">
+                <enum name="CMD_NO_CMD" value="0"/>
+                <enum name="CMD_START_RING" value="1"/>
+                <enum name="CMD_ACK_INTERRUPT" value="2"/>
+                <enum name="CMD_ENUMERATE_STATIONS" value="3"/>
+            </bitfield>
+            <bitfield low="6" high="8" name="CMD_ENUMERATE_STATIONS_BC_GRP" scope="NV_PPRIV_MASTER_RING_COMMAND">
+                <enum name="CMD_ENUMERATE_STATIONS_BC_GRP_ALL" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x120048" name="RING_COMMAND_DATA" variants="GK20A"/>
+        <reg32 offset="0x120050" name="RING_START_RESULTS" variants="GK20A">
+            <bitfield low="0" high="0" name="CONNECTIVITY" scope="NV_PPRIV_MASTER_RING_START_RESULTS">
+                <enum name="CONNECTIVITY_PASS" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x120058" name="RING_INTERRUPT_STATUS0" variants="GK20A"/>
+        <reg32 offset="0x12005c" name="RING_INTERRUPT_STATUS1" variants="GK20A"/>
+        <reg32 offset="0x120060" name="RING_GLOBAL_CTL" variants="GK20A">
+            <bitfield low="0" high="0" name="RING_RESET" scope="NV_PPRIV_MASTER_RING_GLOBAL_CTL">
+                <enum name="RING_RESET_ASSERTED" value="1"/>
+                <enum name="RING_RESET_DEASSERTED" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x120074" name="RING_ENUMERATE_RESULTS_FBP" variants="GK20A">
+            <bitfield low="0" high="4" name="COUNT" scope="NV_PPRIV_MASTER_RING_ENUMERATE_RESULTS_FBP"/>
+        </reg32>
+        <reg32 offset="0x120078" name="RING_ENUMERATE_RESULTS_GPC" variants="GK20A">
+            <bitfield low="0" high="4" name="COUNT" scope="NV_PPRIV_MASTER_RING_ENUMERATE_RESULTS_GPC"/>
+        </reg32>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_priv_sys.xml
+++ b/rnndb/gk20a/gk20a_priv_sys.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_PPRIV_SYS">
+        <reg32 offset="0x122300" name="MASTER_SM_CONFIG" variants="GK20A"/>
+        <reg32 offset="0x122204" name="PRIV_DECODE_CONFIG" variants="GK20A">
+            <bitfield low="0" high="2" name="RING" scope="NV_PPRIV_SYS_PRIV_DECODE_CONFIG">
+                <enum name="RING_DROP_ON_RING_NOT_STARTED" value="1"/>
+            </bitfield>
+        </reg32>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_proj.xml
+++ b/rnndb/gk20a/gk20a_proj.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_HWPROJ">
+        <enum name="NV_GPC_PRI_BASE" value="5242880"/>
+        <enum name="NV_GPC_PRI_SHARED_BASE" value="4292608"/>
+        <enum name="NV_GPC_PRI_STRIDE" value="32768"/>
+        <enum name="NV_LTC_PRI_STRIDE" value="8192"/>
+        <enum name="NV_LTS_PRI_STRIDE" value="1024"/>
+        <enum name="NV_PPC_IN_GPC_BASE" value="12288"/>
+        <enum name="NV_PPC_IN_GPC_STRIDE" value="512"/>
+        <enum name="NV_ROP_PRI_BASE" value="4259840"/>
+        <enum name="NV_ROP_PRI_SHARED_BASE" value="4229120"/>
+        <enum name="NV_ROP_PRI_STRIDE" value="1024"/>
+        <enum name="NV_TPC_IN_GPC_BASE" value="16384"/>
+        <enum name="NV_TPC_IN_GPC_STRIDE" value="2048"/>
+        <enum name="NV_TPC_IN_GPC_SHARED_BASE" value="6144"/>
+        <enum name="NV_HOST_NUM_PBDMA" value="1"/>
+        <enum name="NV_SCAL_LITTER_NUM_TPC_PER_GPC" value="1"/>
+        <enum name="NV_SCAL_LITTER_NUM_FBPS" value="1"/>
+        <enum name="NV_SCAL_LITTER_NUM_GPCS" value="1"/>
+        <enum name="NV_SCAL_LITTER_NUM_PES_PER_GPC" value="1"/>
+        <enum name="NV_SCAL_LITTER_NUM_TPCS_PER_PES" value="1"/>
+        <enum name="NV_SCAL_LITTER_NUM_ZCULL_BANKS" value="4"/>
+        <enum name="NV_SCAL_FAMILY_MAX_GPCS" value="32"/>
+        <enum name="NV_SCAL_FAMILY_MAX_TPC_PER_GPC" value="8"/>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_pwr.xml
+++ b/rnndb/gk20a/gk20a_pwr.xml
@@ -1,0 +1,227 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_PPWR">
+        <reg32 offset="0x10a000" name="FALCON_IRQSSET" variants="GK20A">
+            <bitfield low="6" high="6" name="SWGEN0" scope="NV_PPWR_FALCON_IRQSSET">
+                <enum name="SWGEN0_SET" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x10a004" name="FALCON_IRQSCLR" variants="GK20A"/>
+        <reg32 offset="0x10a008" name="FALCON_IRQSTAT" variants="GK20A">
+            <bitfield low="4" high="4" name="HALT" scope="NV_PPWR_FALCON_IRQSTAT">
+                <enum name="HALT_TRUE" value="1"/>
+            </bitfield>
+            <bitfield low="5" high="5" name="EXTERR" scope="NV_PPWR_FALCON_IRQSTAT">
+                <enum name="EXTERR_TRUE" value="1"/>
+            </bitfield>
+            <bitfield low="6" high="6" name="SWGEN0" scope="NV_PPWR_FALCON_IRQSTAT">
+                <enum name="SWGEN0_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x10a00c" name="FALCON_IRQMODE" variants="GK20A"/>
+        <reg32 offset="0x10a010" name="FALCON_IRQMSET" variants="GK20A">
+            <bitfield low="0" high="0" name="GPTMR" scope="NV_PPWR_FALCON_IRQMSET"/>
+            <bitfield low="1" high="1" name="WDTMR" scope="NV_PPWR_FALCON_IRQMSET"/>
+            <bitfield low="2" high="2" name="MTHD" scope="NV_PPWR_FALCON_IRQMSET"/>
+            <bitfield low="3" high="3" name="CTXSW" scope="NV_PPWR_FALCON_IRQMSET"/>
+            <bitfield low="4" high="4" name="HALT" scope="NV_PPWR_FALCON_IRQMSET"/>
+            <bitfield low="5" high="5" name="EXTERR" scope="NV_PPWR_FALCON_IRQMSET"/>
+            <bitfield low="6" high="6" name="SWGEN0" scope="NV_PPWR_FALCON_IRQMSET"/>
+            <bitfield low="7" high="7" name="SWGEN1" scope="NV_PPWR_FALCON_IRQMSET"/>
+        </reg32>
+        <reg32 offset="0x10a014" name="FALCON_IRQMCLR" variants="GK20A">
+            <bitfield low="0" high="0" name="GPTMR" scope="NV_PPWR_FALCON_IRQMCLR"/>
+            <bitfield low="1" high="1" name="WDTMR" scope="NV_PPWR_FALCON_IRQMCLR"/>
+            <bitfield low="2" high="2" name="MTHD" scope="NV_PPWR_FALCON_IRQMCLR"/>
+            <bitfield low="3" high="3" name="CTXSW" scope="NV_PPWR_FALCON_IRQMCLR"/>
+            <bitfield low="4" high="4" name="HALT" scope="NV_PPWR_FALCON_IRQMCLR"/>
+            <bitfield low="5" high="5" name="EXTERR" scope="NV_PPWR_FALCON_IRQMCLR"/>
+            <bitfield low="6" high="6" name="SWGEN0" scope="NV_PPWR_FALCON_IRQMCLR"/>
+            <bitfield low="7" high="7" name="SWGEN1" scope="NV_PPWR_FALCON_IRQMCLR"/>
+            <bitfield low="8" high="15" name="EXT" scope="NV_PPWR_FALCON_IRQMCLR"/>
+        </reg32>
+        <reg32 offset="0x10a018" name="FALCON_IRQMASK" variants="GK20A"/>
+        <reg32 offset="0x10a01c" name="FALCON_IRQDEST" variants="GK20A">
+            <bitfield low="0" high="0" name="HOST_GPTMR" scope="NV_PPWR_FALCON_IRQDEST"/>
+            <bitfield low="1" high="1" name="HOST_WDTMR" scope="NV_PPWR_FALCON_IRQDEST"/>
+            <bitfield low="2" high="2" name="HOST_MTHD" scope="NV_PPWR_FALCON_IRQDEST"/>
+            <bitfield low="3" high="3" name="HOST_CTXSW" scope="NV_PPWR_FALCON_IRQDEST"/>
+            <bitfield low="4" high="4" name="HOST_HALT" scope="NV_PPWR_FALCON_IRQDEST"/>
+            <bitfield low="5" high="5" name="HOST_EXTERR" scope="NV_PPWR_FALCON_IRQDEST"/>
+            <bitfield low="6" high="6" name="HOST_SWGEN0" scope="NV_PPWR_FALCON_IRQDEST"/>
+            <bitfield low="7" high="7" name="HOST_SWGEN1" scope="NV_PPWR_FALCON_IRQDEST"/>
+            <bitfield low="8" high="15" name="HOST_EXT" scope="NV_PPWR_FALCON_IRQDEST"/>
+            <bitfield low="16" high="16" name="TARGET_GPTMR" scope="NV_PPWR_FALCON_IRQDEST"/>
+            <bitfield low="17" high="17" name="TARGET_WDTMR" scope="NV_PPWR_FALCON_IRQDEST"/>
+            <bitfield low="18" high="18" name="TARGET_MTHD" scope="NV_PPWR_FALCON_IRQDEST"/>
+            <bitfield low="19" high="19" name="TARGET_CTXSW" scope="NV_PPWR_FALCON_IRQDEST"/>
+            <bitfield low="20" high="20" name="TARGET_HALT" scope="NV_PPWR_FALCON_IRQDEST"/>
+            <bitfield low="21" high="21" name="TARGET_EXTERR" scope="NV_PPWR_FALCON_IRQDEST"/>
+            <bitfield low="22" high="22" name="TARGET_SWGEN0" scope="NV_PPWR_FALCON_IRQDEST"/>
+            <bitfield low="23" high="23" name="TARGET_SWGEN1" scope="NV_PPWR_FALCON_IRQDEST"/>
+            <bitfield low="24" high="31" name="TARGET_EXT" scope="NV_PPWR_FALCON_IRQDEST"/>
+        </reg32>
+        <reg32 offset="0x10a050" name="FALCON_CURCTX" variants="GK20A"/>
+        <reg32 offset="0x10a054" name="FALCON_NXTCTX" variants="GK20A"/>
+        <reg32 offset="0x10a040" name="FALCON_MAILBOX0" variants="GK20A"/>
+        <reg32 offset="0x10a044" name="FALCON_MAILBOX1" variants="GK20A"/>
+        <reg32 offset="0x10a048" name="FALCON_ITFEN" variants="GK20A">
+            <bitfield low="0" high="0" name="CTXEN" scope="NV_PPWR_FALCON_ITFEN">
+                <enum name="CTXEN_ENABLE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x10a04c" name="FALCON_IDLESTATE" variants="GK20A">
+            <bitfield low="0" high="0" name="FALCON_BUSY" scope="NV_PPWR_FALCON_IDLESTATE"/>
+            <bitfield low="1" high="15" name="EXT_BUSY" scope="NV_PPWR_FALCON_IDLESTATE"/>
+        </reg32>
+        <reg32 offset="0x10a080" name="FALCON_OS" variants="GK20A"/>
+        <reg32 offset="0x10a0a4" name="FALCON_ENGCTL" variants="GK20A"/>
+        <reg32 offset="0x10a100" name="FALCON_CPUCTL" variants="GK20A">
+            <bitfield low="1" high="1" name="STARTCPU" scope="NV_PPWR_FALCON_CPUCTL"/>
+            <bitfield low="4" high="4" name="HALTED" scope="NV_PPWR_FALCON_CPUCTL"/>
+        </reg32>
+        <reg32 offset="0x10a180" name="FALCON_IMEMC" variants="GK20A">
+            <bitfield low="2" high="7" name="OFFS" scope="NV_PPWR_FALCON_IMEMC"/>
+            <bitfield low="8" high="15" name="BLK" scope="NV_PPWR_FALCON_IMEMC"/>
+            <bitfield low="24" high="24" name="AINCW" scope="NV_PPWR_FALCON_IMEMC"/>
+        </reg32>
+        <reg32 offset="0x10a184" name="FALCON_IMEMD" variants="GK20A"/>
+        <reg32 offset="0x10a188" name="FALCON_IMEMT" variants="GK20A"/>
+        <reg32 offset="0x10a104" name="FALCON_BOOTVEC" variants="GK20A">
+            <bitfield low="0" high="31" name="VEC" scope="NV_PPWR_FALCON_BOOTVEC"/>
+        </reg32>
+        <reg32 offset="0x10a10c" name="FALCON_DMACTL" variants="GK20A">
+            <bitfield low="1" high="1" name="DMEM_SCRUBBING" scope="NV_PPWR_FALCON_DMACTL"/>
+            <bitfield low="2" high="2" name="IMEM_SCRUBBING" scope="NV_PPWR_FALCON_DMACTL"/>
+        </reg32>
+        <reg32 offset="0x10a108" name="FALCON_HWCFG" variants="GK20A">
+            <bitfield low="0" high="8" name="IMEM_SIZE" scope="NV_PPWR_FALCON_HWCFG"/>
+            <bitfield low="9" high="17" name="DMEM_SIZE" scope="NV_PPWR_FALCON_HWCFG"/>
+        </reg32>
+        <reg32 offset="0x10a110" name="FALCON_DMATRFBASE" variants="GK20A"/>
+        <reg32 offset="0x10a114" name="FALCON_DMATRFMOFFS" variants="GK20A"/>
+        <reg32 offset="0x10a118" name="FALCON_DMATRFCMD" variants="GK20A">
+            <bitfield low="4" high="4" name="IMEM" scope="NV_PPWR_FALCON_DMATRFCMD"/>
+            <bitfield low="5" high="5" name="WRITE" scope="NV_PPWR_FALCON_DMATRFCMD"/>
+            <bitfield low="8" high="10" name="SIZE" scope="NV_PPWR_FALCON_DMATRFCMD"/>
+            <bitfield low="12" high="14" name="CTXDMA" scope="NV_PPWR_FALCON_DMATRFCMD"/>
+        </reg32>
+        <reg32 offset="0x10a11c" name="FALCON_DMATRFFBOFFS" variants="GK20A"/>
+        <reg32 offset="0x10a168" name="FALCON_EXTERRADDR" variants="GK20A"/>
+        <reg32 offset="0x10a16c" name="FALCON_EXTERRSTAT" variants="GK20A">
+            <bitfield low="31" high="31" name="VALID" scope="NV_PPWR_FALCON_EXTERRSTAT">
+                <enum name="VALID_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x10a200" name="FALCON_ICD_CMD" variants="GK20A">
+            <bitfield low="0" high="3" name="OPC" scope="NV_PPWR_FALCON_ICD_CMD">
+                <enum name="OPC_RREG" value="8"/>
+                <enum name="OPC_RSTAT" value="14"/>
+            </bitfield>
+            <bitfield low="8" high="12" name="IDX" scope="NV_PPWR_FALCON_ICD_CMD"/>
+        </reg32>
+        <reg32 offset="0x10a20c" name="FALCON_ICD_RDATA" variants="GK20A"/>
+        <reg32 offset="0x10a1c0" name="FALCON_DMEMC" variants="GK20A">
+            <bitfield low="2" high="7" name="OFFS" scope="NV_PPWR_FALCON_DMEMC"/>
+            <bitfield low="8" high="15" name="BLK" scope="NV_PPWR_FALCON_DMEMC"/>
+            <bitfield low="24" high="24" name="AINCW" scope="NV_PPWR_FALCON_DMEMC"/>
+            <bitfield low="25" high="25" name="AINCR" scope="NV_PPWR_FALCON_DMEMC"/>
+        </reg32>
+        <reg32 offset="0x10a1c4" name="FALCON_DMEMD" variants="GK20A"/>
+        <reg32 offset="0x10a480" name="PMU_NEW_INSTBLK" variants="GK20A">
+            <bitfield low="0" high="27" name="PTR" scope="NV_PPWR_PMU_NEW_INSTBLK"/>
+            <bitfield low="28" high="29" name="TARGET" scope="NV_PPWR_PMU_NEW_INSTBLK">
+                <enum name="TARGET_FB" value="0"/>
+                <enum name="TARGET_SYS_COH" value="2"/>
+            </bitfield>
+            <bitfield low="30" high="30" name="VALID" scope="NV_PPWR_PMU_NEW_INSTBLK"/>
+        </reg32>
+        <reg32 offset="0x10a488" name="PMU_MUTEX_ID" variants="GK20A">
+            <bitfield low="0" high="7" name="VALUE" scope="NV_PPWR_PMU_MUTEX_ID">
+                <enum name="VALUE_INIT" value="0"/>
+                <enum name="VALUE_NOT_AVAIL" value="255"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x10a48c" name="PMU_MUTEX_ID_RELEASE" variants="GK20A">
+            <bitfield low="0" high="7" name="VALUE" scope="NV_PPWR_PMU_MUTEX_ID_RELEASE">
+                <enum name="VALUE_INIT" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x10a580" name="PMU_MUTEX" variants="GK20A">
+            <enum name="_SIZE_1" value="16"/>
+            <bitfield low="0" high="7" name="VALUE" scope="NV_PPWR_PMU_MUTEX">
+                <enum name="VALUE_INITIAL_LOCK" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x10a4a0" name="PMU_QUEUE_HEAD" variants="GK20A">
+            <enum name="_SIZE_1" value="4"/>
+            <bitfield low="0" high="31" name="ADDRESS" scope="NV_PPWR_PMU_QUEUE_HEAD"/>
+        </reg32>
+        <reg32 offset="0x10a4b0" name="PMU_QUEUE_TAIL" variants="GK20A">
+            <enum name="_SIZE_1" value="4"/>
+            <bitfield low="0" high="31" name="ADDRESS" scope="NV_PPWR_PMU_QUEUE_TAIL"/>
+        </reg32>
+        <reg32 offset="0x10a4c8" name="PMU_MSGQ_HEAD" variants="GK20A">
+            <bitfield low="0" high="31" name="VAL" scope="NV_PPWR_PMU_MSGQ_HEAD"/>
+        </reg32>
+        <reg32 offset="0x10a4cc" name="PMU_MSGQ_TAIL" variants="GK20A">
+            <bitfield low="0" high="31" name="VAL" scope="NV_PPWR_PMU_MSGQ_TAIL"/>
+        </reg32>
+        <reg32 offset="0x10a504" name="PMU_IDLE_MASK" variants="GK20A">
+            <bitfield low="0" high="0" name="GR" scope="NV_PPWR_PMU_IDLE_MASK">
+                <enum name="GR_ENABLED" value="1"/>
+            </bitfield>
+            <bitfield low="21" high="21" name="CE_2" scope="NV_PPWR_PMU_IDLE_MASK">
+                <enum name="CE_2_ENABLED" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x10a508" name="PMU_IDLE_COUNT" variants="GK20A">
+            <bitfield low="0" high="30" name="VALUE" scope="NV_PPWR_PMU_IDLE_COUNT"/>
+            <bitfield low="31" high="31" name="RESET" scope="NV_PPWR_PMU_IDLE_COUNT"/>
+        </reg32>
+        <reg32 offset="0x10a50c" name="PMU_IDLE_CTRL" variants="GK20A">
+            <bitfield low="0" high="1" name="VALUE" scope="NV_PPWR_PMU_IDLE_CTRL">
+                <enum name="VALUE_BUSY" value="2"/>
+                <enum name="VALUE_ALWAYS" value="3"/>
+            </bitfield>
+            <bitfield low="2" high="2" name="FILTER" scope="NV_PPWR_PMU_IDLE_CTRL">
+                <enum name="FILTER_DISABLED" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x10a9f0" name="PMU_IDLE_MASK_SUPP" variants="GK20A"/>
+        <reg32 offset="0x10a9f4" name="PMU_IDLE_MASK_1_SUPP" variants="GK20A"/>
+        <reg32 offset="0x10aa30" name="PMU_IDLE_CTRL_SUPP" variants="GK20A"/>
+        <reg32 offset="0x10a5c0" name="PMU_DEBUG" variants="GK20A">
+            <enum name="_SIZE_1" value="4"/>
+        </reg32>
+        <reg32 offset="0x10a450" name="PMU_MAILBOX" variants="GK20A">
+            <enum name="_SIZE_1" value="12"/>
+        </reg32>
+        <reg32 offset="0x10a7a0" name="PMU_BAR0_ADDR" variants="GK20A"/>
+        <reg32 offset="0x10a7a4" name="PMU_BAR0_DATA" variants="GK20A"/>
+        <reg32 offset="0x10a7ac" name="PMU_BAR0_CTL" variants="GK20A"/>
+        <reg32 offset="0x10a7a8" name="PMU_BAR0_TIMEOUT" variants="GK20A"/>
+        <reg32 offset="0x10a988" name="PMU_BAR0_FECS_ERROR" variants="GK20A"/>
+        <reg32 offset="0x10a7b0" name="PMU_BAR0_ERROR_STATUS" variants="GK20A"/>
+        <reg32 offset="0x10a6c0" name="PMU_PG_IDLEFILTH" variants="GK20A"/>
+        <reg32 offset="0x10a6e8" name="PMU_PG_PPUIDLEFILTH" variants="GK20A"/>
+        <reg32 offset="0x10a710" name="PMU_PG_IDLE_CNT" variants="GK20A"/>
+        <reg32 offset="0x10a760" name="PMU_PG_INTREN" variants="GK20A"/>
+        <reg32 offset="0x10a600" name="FBIF_TRANSCFG" variants="GK20A">
+            <bitfield low="0" high="1" name="TARGET" scope="NV_PPWR_FBIF_TRANSCFG">
+                <enum name="TARGET_LOCAL_FB" value="0"/>
+                <enum name="TARGET_COHERENT_SYSMEM" value="1"/>
+                <enum name="TARGET_NONCOHERENT_SYSMEM" value="2"/>
+            </bitfield>
+            <bitfield low="2" high="2" name="MEM_TYPE" scope="NV_PPWR_FBIF_TRANSCFG">
+                <enum name="MEM_TYPE_VIRTUAL" value="0"/>
+                <enum name="MEM_TYPE_PHYSICAL" value="1"/>
+            </bitfield>
+        </reg32>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_ram.xml
+++ b/rnndb/gk20a/gk20a_ram.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database  xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_RAM">
+        <reg32 offset="0xffffffff" name="NV_RAMIN" variants="GK20A">
+            <bitfield low="0" high="4095" name="RAMFC" scope="NV_RAMIN"/>
+            <bitfield low="4096" high="4097" name="PAGE_DIR_BASE_TARGET" scope="NV_RAMIN">
+                <enum name="PAGE_DIR_BASE_TARGET_VID_MEM" value="0"/>
+            </bitfield>
+            <bitfield low="4098" high="4098" name="PAGE_DIR_BASE_VOL" scope="NV_RAMIN">
+                <enum name="PAGE_DIR_BASE_VOL_TRUE" value="1"/>
+            </bitfield>
+            <bitfield low="4108" high="4127" name="PAGE_DIR_BASE_LO" scope="NV_RAMIN"/>
+            <bitfield low="4128" high="4135" name="PAGE_DIR_BASE_HI" scope="NV_RAMIN"/>
+            <bitfield low="4172" high="4191" name="ADR_LIMIT_LO" scope="NV_RAMIN"/>
+            <bitfield low="4192" high="4199" name="ADR_LIMIT_HI" scope="NV_RAMIN"/>
+            <bitfield low="4227" high="4227" name="ENGINE_CS" scope="NV_RAMIN">
+                <enum name="ENGINE_CS_WFI" value="0"/>
+                <enum name="ENGINE_CS_FG" value="1"/>
+            </bitfield>
+            <bitfield low="4227" high="4227" name="GR_CS" scope="NV_RAMIN">
+                <enum name="GR_CS_WFI" value="0"/>
+            </bitfield>
+            <bitfield low="4224" high="4225" name="GR_WFI_TARGET" scope="NV_RAMIN"/>
+            <bitfield low="4226" high="4226" name="GR_WFI_MODE" scope="NV_RAMIN">
+                <enum name="GR_WFI_MODE_PHYSICAL" value="0"/>
+                <enum name="GR_WFI_MODE_VIRTUAL" value="1"/>
+            </bitfield>
+            <bitfield low="4236" high="4255" name="GR_WFI_PTR_LO" scope="NV_RAMIN"/>
+            <bitfield low="4256" high="4263" name="GR_WFI_PTR_HI" scope="NV_RAMIN"/>
+            <enum name="BASE_SHIFT" value="12"/>
+            <enum name="ALLOC_SIZE" value="4096"/>
+        </reg32>
+        <reg32 offset="0xffffffff" name="NV_RAMFC" variants="GK20A">
+            <enum name="SIZE_VAL" value="512"/>
+            <bitfield low="0" high="31" name="GP_PUT" scope="NV_RAMFC"/>
+            <bitfield low="64" high="95" name="USERD" scope="NV_RAMFC"/>
+            <bitfield low="96" high="127" name="USERD_HI" scope="NV_RAMFC"/>
+            <bitfield low="128" high="159" name="SIGNATURE" scope="NV_RAMFC"/>
+            <bitfield low="160" high="191" name="GP_GET" scope="NV_RAMFC"/>
+            <bitfield low="192" high="223" name="PB_GET" scope="NV_RAMFC"/>
+            <bitfield low="224" high="255" name="PB_GET_HI" scope="NV_RAMFC"/>
+            <bitfield low="256" high="287" name="PB_TOP_LEVEL_GET" scope="NV_RAMFC"/>
+            <bitfield low="288" high="319" name="PB_TOP_LEVEL_GET_HI" scope="NV_RAMFC"/>
+            <bitfield low="384" high="415" name="ACQUIRE" scope="NV_RAMFC"/>
+            <bitfield low="448" high="479" name="SEMAPHOREA" scope="NV_RAMFC"/>
+            <bitfield low="480" high="511" name="SEMAPHOREB" scope="NV_RAMFC"/>
+            <bitfield low="512" high="543" name="SEMAPHOREC" scope="NV_RAMFC"/>
+            <bitfield low="544" high="575" name="SEMAPHORED" scope="NV_RAMFC"/>
+            <bitfield low="576" high="607" name="GP_BASE" scope="NV_RAMFC"/>
+            <bitfield low="608" high="639" name="GP_BASE_HI" scope="NV_RAMFC"/>
+            <bitfield low="640" high="671" name="GP_FETCH" scope="NV_RAMFC"/>
+            <bitfield low="672" high="703" name="PB_FETCH" scope="NV_RAMFC"/>
+            <bitfield low="704" high="735" name="PB_FETCH_HI" scope="NV_RAMFC"/>
+            <bitfield low="736" high="767" name="PB_PUT" scope="NV_RAMFC"/>
+            <bitfield low="768" high="799" name="PB_PUT_HI" scope="NV_RAMFC"/>
+            <bitfield low="1056" high="1087" name="PB_HEADER" scope="NV_RAMFC"/>
+            <bitfield low="1088" high="1119" name="PB_COUNT" scope="NV_RAMFC"/>
+            <bitfield low="1184" high="1215" name="SUBDEVICE" scope="NV_RAMFC"/>
+            <bitfield low="1248" high="1279" name="FORMATS" scope="NV_RAMFC"/>
+            <bitfield low="1312" high="1343" name="SYNCPOINTA" scope="NV_RAMFC"/>
+            <bitfield low="1344" high="1375" name="SYNCPOINTB" scope="NV_RAMFC"/>
+            <bitfield low="1376" high="1407" name="TARGET" scope="NV_RAMFC"/>
+            <bitfield low="1824" high="1855" name="HCE_CTRL" scope="NV_RAMFC"/>
+            <bitfield low="1856" high="1887" name="CHID" scope="NV_RAMFC"/>
+            <bitfield low="0" high="11" name="CHID_ID" scope="NV_RAMFC"/>
+            <bitfield low="1984" high="2015" name="RUNLIST_TIMESLICE" scope="NV_RAMFC"/>
+            <bitfield low="2016" high="2047" name="PB_TIMESLICE" scope="NV_RAMFC"/>
+        </reg32>
+        <reg32 offset="0xffffffff" name="NV_RAMUSERD" variants="GK20A">
+            <enum name="BASE_SHIFT" value="9"/>
+            <enum name="CHAN_SIZE" value="512"/>
+            <bitfield low="512" high="543" name="PUT" scope="NV_RAMUSERD"/>
+            <bitfield low="544" high="575" name="GET" scope="NV_RAMUSERD"/>
+            <bitfield low="576" high="607" name="REF" scope="NV_RAMUSERD"/>
+            <bitfield low="608" high="639" name="PUT_HI" scope="NV_RAMUSERD"/>
+            <bitfield low="640" high="671" name="REF_THRESHOLD" scope="NV_RAMUSERD"/>
+            <bitfield low="704" high="735" name="TOP_LEVEL_GET" scope="NV_RAMUSERD"/>
+            <bitfield low="736" high="767" name="TOP_LEVEL_GET_HI" scope="NV_RAMUSERD"/>
+            <bitfield low="768" high="799" name="GET_HI" scope="NV_RAMUSERD"/>
+            <bitfield low="1088" high="1119" name="GP_GET" scope="NV_RAMUSERD"/>
+            <bitfield low="1120" high="1151" name="GP_PUT" scope="NV_RAMUSERD"/>
+            <bitfield low="704" high="735" name="GP_TOP_LEVEL_GET" scope="NV_RAMUSERD"/>
+            <bitfield low="736" high="767" name="GP_TOP_LEVEL_GET_HI" scope="NV_RAMUSERD"/>
+        </reg32>
+        <reg32 offset="0xffffffff" name="NV_RAMRL" variants="GK20A">
+            <enum name="ENTRY_SIZE" value="8"/>
+            <bitfield low="0" high="11" name="ENTRY_CHID" scope="NV_RAMRL"/>
+            <bitfield low="0" high="11" name="ENTRY_ID" scope="NV_RAMRL"/>
+            <bitfield low="13" high="13" name="ENTRY_TYPE" scope="NV_RAMRL">
+                <enum name="ENTRY_TYPE_CHID" value="0"/>
+                <enum name="ENTRY_TYPE_TSG" value="1"/>
+            </bitfield>
+            <bitfield low="14" high="17" name="ENTRY_TIMESLICE_SCALE" scope="NV_RAMRL">
+                <enum name="ENTRY_TIMESLICE_SCALE_3" value="3"/>
+            </bitfield>
+            <bitfield low="18" high="25" name="ENTRY_TIMESLICE_TIMEOUT" scope="NV_RAMRL">
+                <enum name="ENTRY_TIMESLICE_TIMEOUT_128" value="128"/>
+            </bitfield>
+            <bitfield low="26" high="31" name="ENTRY_TSG_LENGTH" scope="NV_RAMRL"/>
+        </reg32>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_therm.xml
+++ b/rnndb/gk20a/gk20a_therm.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_THERM">
+        <reg32 offset="0x20798" name="USE_A" variants="GK20A"/>
+        <reg32 offset="0x20700" name="EVT_EXT_THERM_0" variants="GK20A"/>
+        <reg32 offset="0x20704" name="EVT_EXT_THERM_1" variants="GK20A"/>
+        <reg32 offset="0x20708" name="EVT_EXT_THERM_2" variants="GK20A"/>
+        <reg32 offset="0x20024" name="WEIGHT_1" variants="GK20A"/>
+        <reg32 offset="0x20050" name="CONFIG1" variants="GK20A"/>
+        <reg32 offset="0x20200" name="GATE_CTRL" variants="GK20A">
+            <bitfield low="0" high="1" name="ENG_CLK" scope="NV_THERM_GATE_CTRL">
+                <enum name="ENG_CLK_RUN" value="0"/>
+                <enum name="ENG_CLK_AUTO" value="1"/>
+                <enum name="ENG_CLK_STOP" value="2"/>
+            </bitfield>
+            <bitfield low="2" high="3" name="BLK_CLK" scope="NV_THERM_GATE_CTRL">
+                <enum name="BLK_CLK_RUN" value="0"/>
+                <enum name="BLK_CLK_AUTO" value="1"/>
+            </bitfield>
+            <bitfield low="4" high="5" name="ENG_PWR" scope="NV_THERM_GATE_CTRL">
+                <enum name="ENG_PWR_AUTO" value="1"/>
+                <enum name="ENG_PWR_OFF" value="2"/>
+            </bitfield>
+            <bitfield low="8" high="12" name="ENG_IDLE_FILT_EXP" scope="NV_THERM_GATE_CTRL"/>
+            <bitfield low="13" high="15" name="ENG_IDLE_FILT_MANT" scope="NV_THERM_GATE_CTRL"/>
+            <bitfield low="20" high="23" name="ENG_DELAY_AFTER" scope="NV_THERM_GATE_CTRL"/>
+        </reg32>
+        <reg32 offset="0x20288" name="FECS_IDLE_FILTER" variants="GK20A">
+            <bitfield low="0" high="31" name="VALUE" scope="NV_THERM_FECS_IDLE_FILTER"/>
+        </reg32>
+        <reg32 offset="0x2028c" name="HUBMMU_IDLE_FILTER" variants="GK20A">
+            <bitfield low="0" high="31" name="VALUE" scope="NV_THERM_HUBMMU_IDLE_FILTER"/>
+        </reg32>
+        <reg32 offset="0x20160" name="CLK_SLOWDOWN_0" variants="GK20A">
+            <bitfield low="16" high="21" name="IDLE_FACTOR" scope="NV_THERM_CLK_SLOWDOWN_0">
+                <enum name="IDLE_FACTOR_DISABLED" value="0"/>
+            </bitfield>
+        </reg32>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_timer.xml
+++ b/rnndb/gk20a/gk20a_timer.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_PTIMER">
+        <reg32 offset="0x9080" name="PRI_TIMEOUT" variants="GK20A">
+            <bitfield low="0" high="23" name="PERIOD" scope="NV_PTIMER_PRI_TIMEOUT"/>
+            <bitfield low="31" high="31" name="EN" scope="NV_PTIMER_PRI_TIMEOUT">
+                <enum name="EN_ENABLED" value="1"/>
+                <enum name="EN_DISABLED" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x9084" name="PRI_TIMEOUT_SAVE_0" variants="GK20A"/>
+        <reg32 offset="0x9088" name="PRI_TIMEOUT_SAVE_1" variants="GK20A"/>
+        <reg32 offset="0x908c" name="PRI_TIMEOUT_FECS_ERRCODE" variants="GK20A"/>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_top.xml
+++ b/rnndb/gk20a/gk20a_top.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_PTOP">
+        <reg32 offset="0x22430" name="SCAL_NUM_GPCS" variants="GK20A">
+            <bitfield low="0" high="4" name="VALUE" scope="NV_PTOP_SCAL_NUM_GPCS"/>
+        </reg32>
+        <reg32 offset="0x22434" name="SCAL_NUM_TPC_PER_GPC" variants="GK20A">
+            <bitfield low="0" high="4" name="VALUE" scope="NV_PTOP_SCAL_NUM_TPC_PER_GPC"/>
+        </reg32>
+        <reg32 offset="0x22438" name="SCAL_NUM_FBPS" variants="GK20A">
+            <bitfield low="0" high="4" name="VALUE" scope="NV_PTOP_SCAL_NUM_FBPS"/>
+        </reg32>
+        <reg32 offset="0x22700" name="DEVICE_INFO" variants="GK20A">
+            <enum name="_SIZE_1" value="64"/>
+            <bitfield low="31" high="31" name="CHAIN" scope="NV_PTOP_DEVICE_INFO">
+                <enum name="CHAIN_ENABLE" value="1"/>
+            </bitfield>
+            <bitfield low="26" high="29" name="ENGINE_ENUM" scope="NV_PTOP_DEVICE_INFO"/>
+            <bitfield low="21" high="24" name="RUNLIST_ENUM" scope="NV_PTOP_DEVICE_INFO"/>
+            <bitfield low="15" high="19" name="INTR_ENUM" scope="NV_PTOP_DEVICE_INFO"/>
+            <bitfield low="9" high="13" name="RESET_ENUM" scope="NV_PTOP_DEVICE_INFO"/>
+            <bitfield low="2" high="30" name="TYPE_ENUM" scope="NV_PTOP_DEVICE_INFO">
+                <enum name="TYPE_ENUM_GRAPHICS" value="0"/>
+                <enum name="TYPE_ENUM_COPY0" value="1"/>
+            </bitfield>
+            <bitfield low="0" high="1" name="ENTRY" scope="NV_PTOP_DEVICE_INFO">
+                <enum name="ENTRY_NOT_VALID" value="0"/>
+                <enum name="ENTRY_ENUM" value="2"/>
+            </bitfield>
+        </reg32>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_trim.xml
+++ b/rnndb/gk20a/gk20a_trim.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_PTRIM">
+        <reg32 offset="0x137000" name="SYS_GPCPLL_CFG" variants="GK20A">
+            <bitfield low="0" high="0" name="ENABLE" scope="NV_PTRIM_SYS_GPCPLL_CFG">
+                <enum name="ENABLE_NO" value="0"/>
+                <enum name="ENABLE_YES" value="1"/>
+            </bitfield>
+            <bitfield low="1" high="1" name="IDDQ" scope="NV_PTRIM_SYS_GPCPLL_CFG">
+                <enum name="IDDQ_POWER_ON" value="0"/>
+            </bitfield>
+            <bitfield low="4" high="4" name="ENB_LCKDET" scope="NV_PTRIM_SYS_GPCPLL_CFG">
+                <enum name="ENB_LCKDET_POWER_ON" value="0"/>
+                <enum name="ENB_LCKDET_POWER_OFF" value="1"/>
+            </bitfield>
+            <bitfield low="17" high="17" name="PLL_LOCK" scope="NV_PTRIM_SYS_GPCPLL_CFG">
+                <enum name="PLL_LOCK_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x137004" name="SYS_GPCPLL_COEFF" variants="GK20A">
+            <bitfield low="0" high="7" name="MDIV" scope="NV_PTRIM_SYS_GPCPLL_COEFF"/>
+            <bitfield low="8" high="15" name="NDIV" scope="NV_PTRIM_SYS_GPCPLL_COEFF"/>
+            <bitfield low="16" high="21" name="PLDIV" scope="NV_PTRIM_SYS_GPCPLL_COEFF"/>
+        </reg32>
+        <reg32 offset="0x137100" name="SYS_SEL_VCO" variants="GK20A">
+            <bitfield low="0" high="0" name="GPC2CLK_OUT" scope="NV_PTRIM_SYS_SEL_VCO">
+                <enum name="GPC2CLK_OUT_INIT" value="0"/>
+                <enum name="GPC2CLK_OUT_BYPASS" value="0"/>
+                <enum name="GPC2CLK_OUT_VCO" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x137250" name="SYS_GPC2CLK_OUT" variants="GK20A">
+            <bitfield low="0" high="5" name="BYPDIV" scope="NV_PTRIM_SYS_GPC2CLK_OUT">
+                <enum name="BYPDIV_BY31" value="60"/>
+            </bitfield>
+            <bitfield low="8" high="13" name="VCODIV" scope="NV_PTRIM_SYS_GPC2CLK_OUT">
+                <enum name="VCODIV_BY1" value="0"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="SDIV14" scope="NV_PTRIM_SYS_GPC2CLK_OUT">
+                <enum name="SDIV14_INDIV4_MODE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x134124" name="GPC_CLK_CNTR_NCGPCCLK_CFG" variants="GK20A">
+            <bitfield low="0" high="13" name="NOOFIPCLKS" scope="NV_PTRIM_GPC_CLK_CNTR_NCGPCCLK_CFG"/>
+            <bitfield low="16" high="16" name="WRITE_EN" scope="NV_PTRIM_GPC_CLK_CNTR_NCGPCCLK_CFG">
+                <enum name="WRITE_EN_ASSERTED" value="1"/>
+            </bitfield>
+            <bitfield low="20" high="20" name="ENABLE" scope="NV_PTRIM_GPC_CLK_CNTR_NCGPCCLK_CFG">
+                <enum name="ENABLE_ASSERTED" value="1"/>
+            </bitfield>
+            <bitfield low="24" high="24" name="RESET" scope="NV_PTRIM_GPC_CLK_CNTR_NCGPCCLK_CFG">
+                <enum name="RESET_ASSERTED" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x134128" name="GPC_CLK_CNTR_NCGPCCLK_CNT" variants="GK20A">
+            <bitfield low="0" high="19" name="VALUE" scope="NV_PTRIM_GPC_CLK_CNTR_NCGPCCLK_CNT"/>
+        </reg32>
+        <reg32 offset="0x13700c" name="SYS_GPCPLL_CFG2" variants="GK20A">
+            <bitfield low="24" high="31" name="PLL_STEPA" scope="NV_PTRIM_SYS_GPCPLL_CFG2"/>
+        </reg32>
+        <reg32 offset="0x137018" name="SYS_GPCPLL_CFG3" variants="GK20A">
+            <bitfield low="16" high="23" name="PLL_STEPB" scope="NV_PTRIM_SYS_GPCPLL_CFG3"/>
+        </reg32>
+        <reg32 offset="0x13701c" name="SYS_GPCPLL_NDIV_SLOWDOWN" variants="GK20A">
+            <bitfield low="22" high="22" name="SLOWDOWN_USING_PLL" scope="NV_PTRIM_SYS_GPCPLL_NDIV_SLOWDOWN">
+                <enum name="SLOWDOWN_USING_PLL_YES" value="1"/>
+                <enum name="SLOWDOWN_USING_PLL_NO" value="0"/>
+            </bitfield>
+            <bitfield low="31" high="31" name="NV_PTRIM_GPC_GPCPLL_NDIV_SLOWDOWN_EN_DYNRAMP" scope="NV_PTRIM_SYS_GPCPLL_NDIV_SLOWDOWN">
+                <enum name="NV_PTRIM_GPC_GPCPLL_NDIV_SLOWDOWN_EN_DYNRAMP_YES" value="1"/>
+                <enum name="NV_PTRIM_GPC_GPCPLL_NDIV_SLOWDOWN_EN_DYNRAMP_NO" value="0"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x1328a0" name="GPC_BCAST_NDIV_SLOWDOWN_DEBUG" variants="GK20A">
+            <bitfield low="24" high="24" name="PLL_DYNRAMP_DONE_SYNCED" scope="NV_PTRIM_GPC_BCAST_NDIV_SLOWDOWN_DEBUG"/>
+        </reg32>
+    </domain>
+</database>

--- a/rnndb/gk20a/gk20a_uflush.xml
+++ b/rnndb/gk20a/gk20a_uflush.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database xmlns="http://nouveau.freedesktop.org/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
+
+<import file="copyright.xml"/>
+
+    <domain name="NV_UFLUSH">
+        <reg32 offset="0x70004" name="L2_SYSMEM_INVALIDATE" variants="GK20A">
+            <bitfield low="0" high="0" name="PENDING" scope="NV_UFLUSH_L2_SYSMEM_INVALIDATE">
+                <enum name="PENDING_BUSY" value="1"/>
+            </bitfield>
+            <bitfield low="1" high="1" name="OUTSTANDING" scope="NV_UFLUSH_L2_SYSMEM_INVALIDATE">
+                <enum name="OUTSTANDING_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x70010" name="L2_FLUSH_DIRTY" variants="GK20A">
+            <bitfield low="0" high="0" name="PENDING" scope="NV_UFLUSH_L2_FLUSH_DIRTY">
+                <enum name="PENDING_EMPTY" value="0"/>
+                <enum name="PENDING_BUSY" value="1"/>
+            </bitfield>
+            <bitfield low="1" high="1" name="OUTSTANDING" scope="NV_UFLUSH_L2_FLUSH_DIRTY">
+                <enum name="OUTSTANDING_FALSE" value="0"/>
+                <enum name="OUTSTANDING_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+        <reg32 offset="0x70000" name="FB_FLUSH" variants="GK20A">
+            <bitfield low="0" high="0" name="PENDING" scope="NV_UFLUSH_FB_FLUSH">
+                <enum name="PENDING_BUSY" value="1"/>
+            </bitfield>
+            <bitfield low="1" high="1" name="OUTSTANDING" scope="NV_UFLUSH_FB_FLUSH">
+                <enum name="OUTSTANDING_TRUE" value="1"/>
+            </bitfield>
+        </reg32>
+    </domain>
+</database>


### PR DESCRIPTION
This GK20A information corresponds to the set of registers which the
"nvgpu" driver uses.

We will need this information in some form to begin porting/migrating
code from the GPU support in "nvgpu" to nouveau.

I don't expect this change to go in as-it-sits.  So, flame or suggest away :)

Signed-off-by: Ken Adams <kadams@nvidia.com>