### PR TITLE
rnndb/pci: add another kepler pcie reg

### DIFF
--- a/rnndb/bus/pci.xml
+++ b/rnndb/bus/pci.xml
@@ -489,6 +489,20 @@
 			<value value="2" name="2_5GT"/>
 		</bitfield>
 	</reg32>
+	<reg32 offset="0x1c0" name="UNK1C0">
+		<bitfield pos="2" name="PCIE_V2_SUPPORTED" />
+		<bitfield low="16" high="17" name="LNK_CAP_SPEED">
+			<value value="0" name="2_5GT_ALT"/>
+			<value value="1" name="2_5GT"/>
+			<value value="2" name="5_0GT"/>
+			<value value="3" name="8_0GT"/>
+		</bitfield>
+		<bitfield low="20" high="21" name="SYSTEM_MAX_SPEED">
+			<value value="0" name="8_0GT"/>
+			<value value="1" name="5_0GT"/>
+			<value value="2" name="2_5GT"/>
+		</bitfield>
+	</reg32>
 </group>
 
 <domain name="NV_PCI" varset="chipset">

--- a/rnndb/bus/pci.xml
+++ b/rnndb/bus/pci.xml
@@ -489,6 +489,10 @@
 			<value value="2" name="2_5GT"/>
 		</bitfield>
 	</reg32>
+	<reg32 offset="0x080" name="WIDTH">
+		<bitfield low="0" high="7" name="UNK0"/>
+		<bitfield low="8" high="15" name="UNK8"/>
+	</reg32>
 	<reg32 offset="0x1c0" name="UNK1C0">
 		<bitfield pos="2" name="PCIE_V2_SUPPORTED" />
 		<bitfield low="16" high="17" name="LNK_CAP_SPEED">


### PR DESCRIPTION
this reg seems to indicate the configuration max speed like the 0x88460 reg in pre kepler cards. Also the pcie cap speed can be set with bits 16:17