### PR TITLE
nvbios,nvhw,rnndb: Add GM200 chipset

### DIFF
--- a/docs/hw/gpu.rst
+++ b/docs/hw/gpu.rst
@@ -100,7 +100,7 @@ is:
   - GF119 subfamily: GF119, GF117
 
 - Kepler family: GK104, GK107, GK106, GK110, GK110B, GK208, GK208B, GK20A
-- Maxwell family: GM107, GM204
+- Maxwell family: GM107, GM200, GM204
 
 Whenever a range of GPUs is mentioned in the documentation, it's written as
 "NVxx:NVyy". This is left-inclusive, right-noninclusive range of GPU ids
@@ -685,6 +685,7 @@ pciid pciid                   /GPC           /GPC                     /GPC /PART
 128X+ 0e0f  0x106 GK208B ?    ?    ?     ?   ?      ?      ?     \-   ?    ?     ?      3   ?   3   ???
 \-    \-    0xea  GK20A  ?    ?    ?     ?   ?      ?      \-    \-   ?    ?     1      ?   ?   ?   ?
 138X+ 0fbc  0x117 GM107  1    5    2     2   4      3      4     1    2    4     2      3   ?   3   18.02.2014
+17cX+ 0fb0  0x120 GM200  ?    ?    ?     ?   ?      ?      ?     ?    ?    ?     ?      ?   ?   ?   ?
 unk?  ????  0x124 GM204  ?    ?    ?     ?   ?      ?      ?     ?    ?    ?     ?      ?   ?   ?   ?
 ===== ===== ===== ====== ==== ==== ===== === ====== ====== ===== ==== ==== ===== ====== === === === ==========
 
@@ -693,6 +694,8 @@ unk?  ????  0x124 GM204  ?    ?    ?     ?   ?      ?      ?     ?    ?    ?    
 .. todo:: what the fuck is GK110B? and GK208B?
 
 .. todo:: GK20A
+
+.. todo:: GM200
 
 .. todo:: GM204
 

--- a/nvbios/info.c
+++ b/nvbios/info.c
@@ -250,6 +250,11 @@ int envy_bios_parse_bit_i (struct envy_bios *bios, struct envy_bios_bit_entry *b
 			bios->chipset = 0x117;
 			bios->chipset_name = "GM117";
 			break;
+		/* GM200 */
+		case 0x8400:
+			bios->chipset = 0x120;
+			bios->chipset_name = "GM200";
+			break;
 	}
 	if (envy_bios_parse_dacload(bios))
 		ENVY_BIOS_ERR("Failed to parse DACLOAD table at 0x%04x version %d.%d\n", bios->dacload.offset, bios->dacload.version >> 4, bios->dacload.version & 0xf);

--- a/nvhw/chipset.c
+++ b/nvhw/chipset.c
@@ -149,6 +149,7 @@ int parse_pmc_id(uint32_t pmc_id, struct chipset_info *info) {
 			/* maxwell */
 			case 0x117: info->name = "GM107"; break;
 			case 0x118: info->name = "GM108"; break;
+			case 0x120: info->name = "GM200"; break;
 			case 0x124: info->name = "GM204"; break;
 			case 0x126: info->name = "GM206"; break;
 

--- a/rnndb/nvchipsets.xml
+++ b/rnndb/nvchipsets.xml
@@ -93,6 +93,7 @@
 	<value value="0x117" name="GM107"/>
 	<value value="0x118" name="GM108"/>
 	<value value="0x124" name="GM204"/>
+	<value value="0x120" name="GM200"/>
 	<value value="0x126" name="GM206"/>
 </enum>
 


### PR DESCRIPTION
Not sure if I need to add the chipset somewhere else. Some parts of the VBIOS are not properly parsed:

*   BIT 'i' table has strange size: 0x0046 > 0x0044
*   Unknown IUNK21 table version 1.1
*   Failed to parse IUNK21 table at 0xd4aa version 1.1
*   Unknown POWER BUDGET table version 0x30
*   Unknown CSTEP table version 0x8
*   Unknown UNK3C table version 0x20
*   Unknown DCB table version 4.1
*   Failed to parse DCB table at 0x52d1 version 4.1

Should I attach the fix to this PR, or can it be merged in a second one? (I haven't written the fixes yet.) The VBIOS can be found in the nvidia_vbios repo.