### PR TITLE
nvbios: parse the VID entry voltage right for ver 0x50

### DIFF
--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -1811,12 +1811,12 @@ int main(int argc, char **argv) {
 			start += header_length;
 
 			for (i = 0; i < entry_count; i++) {
-				volt = le32(start) & 0x000fffff;
+				volt = le32(start) & 0x001fffff;
 
 				if (is_pwm_based) {
-					printf("-- Vid %d, voltage %d µV (unk = %d) --\n", i, volt, le32(start) >> 20);
+					printf("-- Vid %d, voltage %d µV (unk = %d) --\n", i, volt, le32(start) >> 21);
 				} else {
-					printf("-- Vid %d, voltage %d µV/%d µV (unk = %d) --\n", i, volt_uv, volt, le32(start) >> 20);
+					printf("-- Vid %d, voltage %d µV/%d µV (unk = %d) --\n", i, volt_uv, volt, le32(start) >> 21);
 					volt_uv += step_uv;
 					/* List the gpio tags assosiated with each voltage id */
 					int j;


### PR DESCRIPTION
This value needs to be a bit bigger for the voltage because otherweise we would have beend a maximum value of 1048575 uv and this is obviously not enough.

I think that two more bits can be added to that field, but I want to be rather safe here and just add this one bit