### PR TITLE
rrnd/graph: add some missing unknown bits for GK110_COMPUTE-

### DIFF
--- a/rnndb/graph/gk104_compute.xml
+++ b/rnndb/graph/gk104_compute.xml
@@ -14,6 +14,9 @@ xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
 		<doc>State that also exists on GK104_3D (like CODE,TEMP,TIC,TSC_ADDRESS)
 		seems to be kept separate from the 3D object.</doc>
 		<use-group name="gk104_upload"/>
+		<reg32 offset="0x0200" name="UNK0200" variants="GK110_COMPUTE-"/>
+		<reg32 offset="0x0204" name="UNK0204" variants="GK110_COMPUTE-"/>
+		<reg32 offset="0x0208" name="UNK0208" variants="GK110_COMPUTE-"/>
 		<reg32 offset="0x0214" name="SHARED_BASE">
 			<doc>32 bit address, not shifted. Contents of $sbase register.</doc>
 		</reg32>
@@ -39,6 +42,7 @@ xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
 		<reg32 offset="0x02b4" name="LAUNCH_DESC_ADDRESS" shr="8"/>
 		<reg32 offset="0x02b8" name="UNK02B8"/> <!-- ffffffff -->
 		<reg32 offset="0x02bc" name="LAUNCH"/> <!-- 3 -->
+		<reg32 offset="0x02c4" name="UNK02C4" variants="GK110_COMPUTE-"/>
 		<array offset="0x02e4" name="MP_TEMP_SIZE" length="2" stride="0xc">
 			<doc>The TEMP area is split among MPs, where each MP gets assigned a single contiguous block.
 			This specifies the size a single MP is awarded, so it should be set to the actual size of the
@@ -60,6 +64,7 @@ xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
 		<reg32 offset="0x0f44" name="UNK0F44" length="4"/> <!-- ffffffff -->
 		<reg32 offset="0x1040" name="UNK1040" length="12"/> <!-- ffffffff -->
 		<reg32 offset="0x1288" name="UNK1288_TIC_FLUSH"/>
+		<reg32 offset="0x12a8" name="UNK12A8" variants="GK110_COMPUTE-"/>
 		<reg32 offset="0x1330" name="TSC_FLUSH">
 			<bitfield pos="0" name="SPECIFIC"/>
 			<bitfield low="4" high="25" name="ENTRY"/>


### PR DESCRIPTION
These commands seem to be only available for GK110+. Note they are already used in the compute support in mesa.