### PR TITLE
envydis: add missing input reg for lop3 insn on GM107

### DIFF
--- a/envydis/gm107.c
+++ b/envydis/gm107.c
@@ -1818,7 +1818,7 @@ static struct insn tabroot[] = {
 	{ 0x0c00000000000000ull, 0xfc00000000000000ull, OP8B, T(pred), N(    "ffma32i"), T(5980_0), ON(55, sat), ON(52, cc), REG_00, ON(56, neg), REG_08, F32_20, ON(57, neg), REG_00 /*hmm*/ },
 	{ 0x0800000000000000ull, 0xfc00000000000000ull, OP8B, T(pred), N(    "fadd32i"), ON(55, ftz), ON(52, cc), REG_00, ON(56, neg), ON(54, abs), REG_08, ON(53, neg), ON(57, abs), F32_20 },
 	{ 0x0400000000000000ull, 0xfc00000000000000ull, OP8B, T(pred), N(     "lop32i"), T(0400_0), ON(57, x), ON(52, cc), REG_00, ON(55, inv), REG_08, ON(56, inv), U32_20 },
-	{ 0x0200000000000000ull, 0xfe00000000000000ull, OP8B, T(pred), N(       "lop3"), N("lut"), ON(56, x), ON(47, cc), REG_00, C34_RZ_O14_20, REG_39, U08_48 },
+	{ 0x0200000000000000ull, 0xfe00000000000000ull, OP8B, T(pred), N(       "lop3"), N("lut"), ON(56, x), ON(47, cc), REG_00, REG_08, C34_RZ_O14_20, REG_39, U08_48 },
 	{ 0x0100000000000000ull, 0xfff0000000000000ull, OP8B, T(pred), N(     "mov32i"), REG_00, U32_20, U04_12 },
 	/*XXX: hw expects this data prior to every 3 insns, this is a compromise between printing most scheds, and not disasm'ing other unknowns as sched */
 	{ 0x0000000000000000ull, 0xf000000000000000ull, OP8B,          N(      "sched"), SCHED0, SCHED1, SCHED2 },


### PR DESCRIPTION
There is actually three input regs and one output reg.