### PR TITLE
Use pkg_search_module() to find the python3 pkgconfig file.

### DIFF
--- a/nva/CMakeLists.txt
+++ b/nva/CMakeLists.txt
@@ -7,7 +7,7 @@ if (NOT DISABLE_NVA)
 	pkg_check_modules(PC_PCIACCESS pciaccess)
 	pkg_check_modules(PC_X11 x11)
 	pkg_check_modules(PC_XEXT xext)
-	pkg_check_modules(PC_PYTHON python3)
+	pkg_search_module(PC_PYTHON python3 python-3.5)
 	find_package (Threads)
 	find_program (CYTHON_EXECUTABLE cython)
 


### PR DESCRIPTION
I researched this further, when compiled from source python3 by default will only provide a python3-3.5.pc file, although it seems many distros softlink it to python3.pc among another names. It would probably be best to support finding the default python3-3.5.pc file instead of just a softlink to it.