### PR TITLE
Parsing of unknown D, L, T and d BIT Tables

### DIFF
--- a/nvbios/CMakeLists.txt
+++ b/nvbios/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(envybios
 	bit.c info.c dacload.c iunk.c
 	i2cscript.c
 	dcb.c dunk.c i2c.c gpio.c extdev.c conn.c mem.c mux.c power.c
-	D.c L.c T.c
+	D.c L.c T.c d.c
 )
 
 add_executable(nvbios nvbios.c)

--- a/nvbios/CMakeLists.txt
+++ b/nvbios/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(envybios
 	bit.c info.c dacload.c iunk.c
 	i2cscript.c
 	dcb.c dunk.c i2c.c gpio.c extdev.c conn.c mem.c mux.c power.c
+	D.c
 )
 
 add_executable(nvbios nvbios.c)

--- a/nvbios/CMakeLists.txt
+++ b/nvbios/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(envybios
 	bit.c info.c dacload.c iunk.c
 	i2cscript.c
 	dcb.c dunk.c i2c.c gpio.c extdev.c conn.c mem.c mux.c power.c
-	D.c L.c
+	D.c L.c T.c
 )
 
 add_executable(nvbios nvbios.c)

--- a/nvbios/CMakeLists.txt
+++ b/nvbios/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(envybios
 	bit.c info.c dacload.c iunk.c
 	i2cscript.c
 	dcb.c dunk.c i2c.c gpio.c extdev.c conn.c mem.c mux.c power.c
-	D.c
+	D.c L.c
 )
 
 add_executable(nvbios nvbios.c)

--- a/nvbios/D.c
+++ b/nvbios/D.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2016 Karol Herbst
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "bios.h"
+
+struct D_known_tables {
+	uint8_t offset;
+	uint16_t *ptr;
+	const char *name;
+};
+
+static int
+parse_at(struct envy_bios *bios, unsigned int idx, const char **name)
+{
+	struct envy_bios_D *d = &bios->D;
+	struct D_known_tables tbls[] = {
+		{ 0x0, &d->unk0.offset, "UNK0" },
+		{ 0x2, &d->unk2.offset, "UNK2 TABLE" },
+	};
+	int entries_count = (sizeof(tbls) / sizeof(struct D_known_tables));
+
+	/* check the index */
+	if (idx >= entries_count)
+		return -ENOENT;
+
+	/* check the table has the right size */
+	if (tbls[idx].offset + 2 > d->bit->t_len)
+		return -ENOENT;
+
+	if (name)
+		*name = tbls[idx].name;
+
+	return bios_u16(bios, d->bit->t_offset + tbls[idx].offset, tbls[idx].ptr);
+}
+
+int
+envy_bios_parse_bit_D(struct envy_bios *bios, struct envy_bios_bit_entry *bit)
+{
+	struct envy_bios_D *d = &bios->D;
+	unsigned int idx = 0;
+
+	d->bit = bit;
+
+	while (!parse_at(bios, idx, NULL))
+		idx++;
+
+	/* parse tables */
+
+	return 0;
+}
+
+void
+envy_bios_print_bit_D(struct envy_bios *bios, FILE *out, unsigned mask)
+{
+	struct envy_bios_D *d = &bios->D;
+	uint16_t addr;
+	int ret = 0, i = 0;
+
+	if (!d->bit || !(mask & ENVY_BIOS_PRINT_D))
+		return;
+
+	fprintf(out, "BIT table 'D' at 0x%x, version %i\n",
+		d->bit->offset, d->bit->version);
+
+	for (i = 0; i * 2 < d->bit->t_len; ++i) {
+		ret = bios_u16(bios, d->bit->t_offset + (i * 2), &addr);
+		if (!ret && addr) {
+			const char *name;
+			ret = parse_at(bios, i, &name);
+			fprintf(out, "0x%02x: 0x%x => D %s\n", i * 2, addr, name);
+		}
+	}
+
+	fprintf(out, "\n");
+}

--- a/nvbios/D.c
+++ b/nvbios/D.c
@@ -24,6 +24,8 @@
 
 #include "bios.h"
 
+static void envy_bios_parse_D_unk2(struct envy_bios *);
+
 struct D_known_tables {
 	uint8_t offset;
 	uint16_t *ptr;
@@ -66,6 +68,7 @@ envy_bios_parse_bit_D(struct envy_bios *bios, struct envy_bios_bit_entry *bit)
 		idx++;
 
 	/* parse tables */
+	envy_bios_parse_D_unk2(bios);
 
 	return 0;
 }
@@ -90,6 +93,61 @@ envy_bios_print_bit_D(struct envy_bios *bios, FILE *out, unsigned mask)
 			ret = parse_at(bios, i, &name);
 			fprintf(out, "0x%02x: 0x%x => D %s\n", i * 2, addr, name);
 		}
+	}
+
+	fprintf(out, "\n");
+}
+
+static void
+envy_bios_parse_D_unk2(struct envy_bios *bios)
+{
+	struct envy_bios_D_unk2 *unk2 = &bios->D.unk2;
+	int err = 0, i;
+
+	if (!unk2->offset)
+		return;
+
+	bios_u8(bios, unk2->offset, &unk2->version);
+	switch (unk2->version) {
+	case 0x20:
+		err |= bios_u8(bios, unk2->offset + 0x1, &unk2->hlen);
+		err |= bios_u8(bios, unk2->offset + 0x2, &unk2->rlen);
+		err |= bios_u8(bios, unk2->offset + 0x3, &unk2->entriesnum);
+		unk2->valid = !err;
+		break;
+	default:
+		ENVY_BIOS_ERR("Unknown UNK2 table version 0x%x\n", unk2->version);
+		return;
+	}
+
+	unk2->entries = malloc(unk2->entriesnum * sizeof(struct envy_bios_D_unk2_entry));
+	for (i = 0; i < unk2->entriesnum; ++i) {
+		struct envy_bios_D_unk2_entry *e = &unk2->entries[i];
+		e->offset = unk2->offset + unk2->hlen + i * unk2->rlen;
+	}
+}
+
+void
+envy_bios_print_d_unk2(struct envy_bios *bios, FILE *out, unsigned mask)
+{
+	struct envy_bios_D_unk2 *unk2 = &bios->D.unk2;
+	int i;
+
+	if (!unk2->offset || !(mask & ENVY_BIOS_PRINT_D))
+		return;
+	if (!unk2->valid) {
+		ENVY_BIOS_ERR("Failed to parse D UNK2 table at 0x%x, version %x\n\n", unk2->offset, unk2->version);
+		return;
+	}
+
+	fprintf(out, "D UNK2 table at 0x%x, version %x\n", unk2->offset, unk2->version);
+	envy_bios_dump_hex(bios, out, unk2->offset, unk2->hlen, mask);
+	if (mask & ENVY_BIOS_PRINT_VERBOSE) fprintf(out, "\n");
+
+	for (i = 0; i < unk2->entriesnum; ++i) {
+		struct envy_bios_D_unk2_entry *e = &unk2->entries[i];
+		envy_bios_dump_hex(bios, out, e->offset, unk2->rlen, mask);
+		if (mask & ENVY_BIOS_PRINT_VERBOSE) fprintf(out, "\n");
 	}
 
 	fprintf(out, "\n");

--- a/nvbios/D.c
+++ b/nvbios/D.c
@@ -24,6 +24,7 @@
 
 #include "bios.h"
 
+static void envy_bios_parse_D_unk0(struct envy_bios *);
 static void envy_bios_parse_D_unk2(struct envy_bios *);
 
 struct D_known_tables {
@@ -68,6 +69,7 @@ envy_bios_parse_bit_D(struct envy_bios *bios, struct envy_bios_bit_entry *bit)
 		idx++;
 
 	/* parse tables */
+	envy_bios_parse_D_unk0(bios);
 	envy_bios_parse_D_unk2(bios);
 
 	return 0;
@@ -93,6 +95,54 @@ envy_bios_print_bit_D(struct envy_bios *bios, FILE *out, unsigned mask)
 			ret = parse_at(bios, i, &name);
 			fprintf(out, "0x%02x: 0x%x => D %s\n", i * 2, addr, name);
 		}
+	}
+
+	fprintf(out, "\n");
+}
+
+static void
+envy_bios_parse_D_unk0(struct envy_bios *bios)
+{
+	struct envy_bios_D_unk0 *unk0 = &bios->D.unk0;
+	int i;
+
+	if (!unk0->offset)
+		return;
+
+	unk0->version = 0;
+	unk0->hlen = 0;
+	unk0->rlen = 18;
+	unk0->entriesnum = 11;
+	unk0->valid = 1;
+
+	unk0->entries = malloc(unk0->entriesnum * sizeof(struct envy_bios_D_unk0_entry));
+	for (i = 0; i < unk0->entriesnum; ++i) {
+		struct envy_bios_D_unk0_entry *e = &unk0->entries[i];
+		e->offset = unk0->offset + unk0->hlen + i * unk0->rlen;
+	}
+}
+
+void
+envy_bios_print_d_unk0(struct envy_bios *bios, FILE *out, unsigned mask)
+{
+	struct envy_bios_D_unk0 *unk0 = &bios->D.unk0;
+	int i;
+
+	if (!unk0->offset || !(mask & ENVY_BIOS_PRINT_D))
+		return;
+	if (!unk0->valid) {
+		ENVY_BIOS_ERR("Failed to parse D UNK0 table at 0x%x, version %x\n\n", unk0->offset, unk0->version);
+		return;
+	}
+
+	fprintf(out, "D UNK0 at 0x%x, version %x\n", unk0->offset, unk0->version);
+	envy_bios_dump_hex(bios, out, unk0->offset, unk0->hlen, mask);
+	if (mask & ENVY_BIOS_PRINT_VERBOSE) fprintf(out, "\n");
+
+	for (i = 0; i < unk0->entriesnum; ++i) {
+		struct envy_bios_D_unk0_entry *e = &unk0->entries[i];
+		envy_bios_dump_hex(bios, out, e->offset, unk0->rlen, mask);
+		if (mask & ENVY_BIOS_PRINT_VERBOSE) fprintf(out, "\n");
 	}
 
 	fprintf(out, "\n");

--- a/nvbios/L.c
+++ b/nvbios/L.c
@@ -24,6 +24,8 @@
 
 #include "bios.h"
 
+static void envy_bios_parse_L_unk0(struct envy_bios *);
+
 struct L_known_tables {
 	uint8_t offset;
 	uint16_t *ptr;
@@ -65,6 +67,7 @@ envy_bios_parse_bit_L(struct envy_bios *bios, struct envy_bios_bit_entry *bit)
 		idx++;
 
 	/* parse tables */
+	envy_bios_parse_L_unk0(bios);
 
 	return 0;
 }
@@ -89,6 +92,62 @@ envy_bios_print_bit_L(struct envy_bios *bios, FILE *out, unsigned mask)
 			ret = parse_at(bios, i, &name);
 			fprintf(out, "0x%02x: 0x%x => L %s\n", i * 2, addr, name);
 		}
+	}
+
+	fprintf(out, "\n");
+}
+
+static void
+envy_bios_parse_L_unk0(struct envy_bios *bios)
+{
+	struct envy_bios_L_unk0 *unk0 = &bios->L.unk0;
+	int err = 0, i;
+
+	if (!unk0->offset)
+		return;
+
+	bios_u8(bios, unk0->offset, &unk0->version);
+	switch (unk0->version) {
+	case 0x30:
+	case 0x40:
+		err |= bios_u8(bios, unk0->offset + 0x1, &unk0->hlen);
+		err |= bios_u8(bios, unk0->offset + 0x2, &unk0->rlen);
+		err |= bios_u8(bios, unk0->offset + 0x3, &unk0->entriesnum);
+		unk0->valid = !err;
+		break;
+	default:
+		ENVY_BIOS_ERR("Unknown L UNK0 table version 0x%x\n", unk0->version);
+		return;
+	}
+
+	unk0->entries = malloc(unk0->entriesnum * sizeof(struct envy_bios_L_unk0_entry));
+	for (i = 0; i < unk0->entriesnum; ++i) {
+		struct envy_bios_L_unk0_entry *e = &unk0->entries[i];
+		e->offset = unk0->offset + unk0->hlen + i * unk0->rlen;
+	}
+}
+
+void
+envy_bios_print_L_unk0(struct envy_bios *bios, FILE *out, unsigned mask)
+{
+	struct envy_bios_L_unk0 *unk0 = &bios->L.unk0;
+	int i;
+
+	if (!unk0->offset || !(mask & ENVY_BIOS_PRINT_L))
+		return;
+	if (!unk0->valid) {
+		ENVY_BIOS_ERR("Failed to parse L UNK0 table at 0x%x, version %x\n\n", unk0->offset, unk0->version);
+		return;
+	}
+
+	fprintf(out, "L UNK0 table at 0x%x, version %x\n", unk0->offset, unk0->version);
+	envy_bios_dump_hex(bios, out, unk0->offset, unk0->hlen, mask);
+	if (mask & ENVY_BIOS_PRINT_VERBOSE) fprintf(out, "\n");
+
+	for (i = 0; i < unk0->entriesnum; ++i) {
+		struct envy_bios_L_unk0_entry *e = &unk0->entries[i];
+		envy_bios_dump_hex(bios, out, e->offset, unk0->rlen, mask);
+		if (mask & ENVY_BIOS_PRINT_VERBOSE) fprintf(out, "\n");
 	}
 
 	fprintf(out, "\n");

--- a/nvbios/L.c
+++ b/nvbios/L.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2016 Karol Herbst
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "bios.h"
+
+struct L_known_tables {
+	uint8_t offset;
+	uint16_t *ptr;
+	const char *name;
+};
+
+static int
+parse_at(struct envy_bios *bios, unsigned int idx, const char **name)
+{
+	struct envy_bios_L *l = &bios->L;
+	struct L_known_tables tbls[] = {
+		{ 0x0, &l->unk0.offset, "UNK0 TABLE" },
+	};
+	int entries_count = (sizeof(tbls) / sizeof(struct L_known_tables));
+
+	/* check the index */
+	if (idx >= entries_count)
+		return -ENOENT;
+
+	/* check the table has the right size */
+	if (tbls[idx].offset + 2 > l->bit->t_len)
+		return -ENOENT;
+
+	if (name)
+		*name = tbls[idx].name;
+
+	return bios_u16(bios, l->bit->t_offset + tbls[idx].offset, tbls[idx].ptr);
+}
+
+int
+envy_bios_parse_bit_L(struct envy_bios *bios, struct envy_bios_bit_entry *bit)
+{
+	struct envy_bios_L *l = &bios->L;
+	unsigned int idx = 0;
+
+	l->bit = bit;
+
+	while (!parse_at(bios, idx, NULL))
+		idx++;
+
+	/* parse tables */
+
+	return 0;
+}
+
+void
+envy_bios_print_bit_L(struct envy_bios *bios, FILE *out, unsigned mask)
+{
+	struct envy_bios_L *l = &bios->L;
+	uint16_t addr;
+	int ret = 0, i = 0;
+
+	if (!l->bit || !(mask & ENVY_BIOS_PRINT_L))
+		return;
+
+	fprintf(out, "BIT table 'L' at 0x%x, version %i\n",
+		l->bit->offset, l->bit->version);
+
+	for (i = 0; i * 2 < l->bit->t_len; ++i) {
+		ret = bios_u16(bios, l->bit->t_offset + (i * 2), &addr);
+		if (!ret && addr) {
+			const char *name;
+			ret = parse_at(bios, i, &name);
+			fprintf(out, "0x%02x: 0x%x => L %s\n", i * 2, addr, name);
+		}
+	}
+
+	fprintf(out, "\n");
+}

--- a/nvbios/T.c
+++ b/nvbios/T.c
@@ -24,6 +24,8 @@
 
 #include "bios.h"
 
+static void envy_bios_parse_T_unk0(struct envy_bios *);
+
 struct T_known_tables {
 	uint8_t offset;
 	uint16_t *ptr;
@@ -65,6 +67,7 @@ envy_bios_parse_bit_T(struct envy_bios *bios, struct envy_bios_bit_entry *bit)
 		idx++;
 
 	/* parse tables */
+	envy_bios_parse_T_unk0(bios);
 
 	return 0;
 }
@@ -89,6 +92,62 @@ envy_bios_print_bit_T(struct envy_bios *bios, FILE *out, unsigned mask)
 			ret = parse_at(bios, i, &name);
 			fprintf(out, "0x%02x: 0x%x => T %s\n", i * 2, addr, name);
 		}
+	}
+
+	fprintf(out, "\n");
+}
+
+static void
+envy_bios_parse_T_unk0(struct envy_bios *bios)
+{
+	struct envy_bios_T_unk0 *unk0 = &bios->T.unk0;
+	int err = 0, i;
+
+	if (!unk0->offset)
+		return;
+
+	bios_u8(bios, unk0->offset, &unk0->version);
+	switch (unk0->version) {
+	case 0x11:
+	case 0x20:
+		err |= bios_u8(bios, unk0->offset + 0x1, &unk0->hlen);
+		err |= bios_u8(bios, unk0->offset + 0x2, &unk0->rlen);
+		err |= bios_u8(bios, unk0->offset + 0x3, &unk0->entriesnum);
+		unk0->valid = !err;
+		break;
+	default:
+		ENVY_BIOS_ERR("Unknown T UNK0 table version 0x%x\n", unk0->version);
+		return;
+	}
+
+	unk0->entries = malloc(unk0->entriesnum * sizeof(struct envy_bios_T_unk0_entry));
+	for (i = 0; i < unk0->entriesnum; ++i) {
+		struct envy_bios_T_unk0_entry *e = &unk0->entries[i];
+		e->offset = unk0->offset + unk0->hlen + i * unk0->rlen;
+	}
+}
+
+void
+envy_bios_print_T_unk0(struct envy_bios *bios, FILE *out, unsigned mask)
+{
+	struct envy_bios_T_unk0 *unk0 = &bios->T.unk0;
+	int i;
+
+	if (!unk0->offset || !(mask & ENVY_BIOS_PRINT_T))
+		return;
+	if (!unk0->valid) {
+		ENVY_BIOS_ERR("Failed to parse T UNK0 table at 0x%x, version %x\n\n", unk0->offset, unk0->version);
+		return;
+	}
+
+	fprintf(out, "T unk0 table at 0x%x, version %x\n", unk0->offset, unk0->version);
+	envy_bios_dump_hex(bios, out, unk0->offset, unk0->hlen, mask);
+	if (mask & ENVY_BIOS_PRINT_VERBOSE) fprintf(out, "\n");
+
+	for (i = 0; i < unk0->entriesnum; ++i) {
+		struct envy_bios_T_unk0_entry *e = &unk0->entries[i];
+		envy_bios_dump_hex(bios, out, e->offset, unk0->rlen, mask);
+		if (mask & ENVY_BIOS_PRINT_VERBOSE) fprintf(out, "\n");
 	}
 
 	fprintf(out, "\n");

--- a/nvbios/T.c
+++ b/nvbios/T.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2016 Karol Herbst
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "bios.h"
+
+struct T_known_tables {
+	uint8_t offset;
+	uint16_t *ptr;
+	const char *name;
+};
+
+static int
+parse_at(struct envy_bios *bios, unsigned int idx, const char **name)
+{
+	struct envy_bios_T *t = &bios->T;
+	struct T_known_tables tbls[] = {
+		{ 0x0, &t->unk0.offset, "UNK0 TABLE" },
+	};
+	int entries_count = (sizeof(tbls) / sizeof(struct T_known_tables));
+
+	/* check the index */
+	if (idx >= entries_count)
+		return -ENOENT;
+
+	/* check the table has the right size */
+	if (tbls[idx].offset + 2 > t->bit->t_len)
+		return -ENOENT;
+
+	if (name)
+		*name = tbls[idx].name;
+
+	return bios_u16(bios, t->bit->t_offset + tbls[idx].offset, tbls[idx].ptr);
+}
+
+int
+envy_bios_parse_bit_T(struct envy_bios *bios, struct envy_bios_bit_entry *bit)
+{
+	struct envy_bios_T *t = &bios->T;
+	unsigned int idx = 0;
+
+	t->bit = bit;
+
+	while (!parse_at(bios, idx, NULL))
+		idx++;
+
+	/* parse tables */
+
+	return 0;
+}
+
+void
+envy_bios_print_bit_T(struct envy_bios *bios, FILE *out, unsigned mask)
+{
+	struct envy_bios_T *t = &bios->T;
+	uint16_t addr;
+	int ret = 0, i = 0;
+
+	if (!t->bit || !(mask & ENVY_BIOS_PRINT_T))
+		return;
+
+	fprintf(out, "BIT table 'T' at 0x%x, version %i\n",
+		t->bit->offset, t->bit->version);
+
+	for (i = 0; i * 2 < t->bit->t_len; ++i) {
+		ret = bios_u16(bios, t->bit->t_offset + (i * 2), &addr);
+		if (!ret && addr) {
+			const char *name;
+			ret = parse_at(bios, i, &name);
+			fprintf(out, "0x%02x: 0x%x => T %s\n", i * 2, addr, name);
+		}
+	}
+
+	fprintf(out, "\n");
+}

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -1428,6 +1428,7 @@ void envy_bios_print_T_unk0(struct envy_bios *, FILE *out, unsigned mask);
 
 int envy_bios_parse_bit_d(struct envy_bios *, struct envy_bios_bit_entry *);
 void envy_bios_print_bit_d(struct envy_bios *, FILE *out, unsigned mask);
+void envy_bios_print_d_unk0(struct envy_bios *, FILE *out, unsigned mask);
 
 int envy_bios_parse_dcb (struct envy_bios *bios);
 void envy_bios_print_dcb (struct envy_bios *bios, FILE *out, unsigned mask);

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -1401,6 +1401,7 @@ void envy_bios_print_L_unk0(struct envy_bios *, FILE *out, unsigned mask);
 
 int envy_bios_parse_bit_T(struct envy_bios *, struct envy_bios_bit_entry *);
 void envy_bios_print_bit_T(struct envy_bios *, FILE *out, unsigned mask);
+void envy_bios_print_T_unk0(struct envy_bios *, FILE *out, unsigned mask);
 
 int envy_bios_parse_dcb (struct envy_bios *bios);
 void envy_bios_print_dcb (struct envy_bios *bios, FILE *out, unsigned mask);

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -1346,6 +1346,7 @@ void envy_bios_print_mem_type(struct envy_bios *bios, FILE *out, unsigned mask);
 
 int envy_bios_parse_bit_D (struct envy_bios *, struct envy_bios_bit_entry *);
 void envy_bios_print_bit_D (struct envy_bios *, FILE *out, unsigned mask);
+void envy_bios_print_d_unk2(struct envy_bios *, FILE *out, unsigned mask);
 
 int envy_bios_parse_dcb (struct envy_bios *bios);
 void envy_bios_print_dcb (struct envy_bios *bios, FILE *out, unsigned mask);

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -1186,6 +1186,27 @@ struct envy_bios_T {
 	struct envy_bios_T_unk0 unk0;
 };
 
+struct envy_bios_d_unk0_entry {
+	uint16_t offset;
+};
+
+struct envy_bios_d_unk0 {
+	uint16_t offset;
+	uint8_t valid;
+	uint8_t version;
+	uint8_t hlen;
+	uint8_t entriesnum;
+	uint8_t rlen;
+
+	struct envy_bios_d_unk0_entry *entries;
+};
+
+struct envy_bios_d {
+	struct envy_bios_bit_entry *bit;
+
+	struct envy_bios_d_unk0 unk0;
+};
+
 struct envy_bios_block {
 	unsigned int start;
 	unsigned int len;
@@ -1264,6 +1285,7 @@ struct envy_bios {
 	struct envy_bios_D D;
 	struct envy_bios_L L;
 	struct envy_bios_T T;
+	struct envy_bios_d d;
 
 	struct envy_bios_block *blocks;
 	int blocksnum;
@@ -1337,6 +1359,7 @@ static inline int bios_string(struct envy_bios *bios, unsigned int offs, char *r
 #define ENVY_BIOS_PRINT_DUNK		0x00400000
 #define ENVY_BIOS_PRINT_DCB_ALL		0x007f0000
 #define ENVY_BIOS_PRINT_T		0x00800000
+#define ENVY_BIOS_PRINT_d		0x01000000
 #define ENVY_BIOS_PRINT_ALL		0x1fffffff
 #define ENVY_BIOS_PRINT_BLOCKS		0x20000000
 #define ENVY_BIOS_PRINT_UNUSED		0x40000000
@@ -1402,6 +1425,9 @@ void envy_bios_print_L_unk0(struct envy_bios *, FILE *out, unsigned mask);
 int envy_bios_parse_bit_T(struct envy_bios *, struct envy_bios_bit_entry *);
 void envy_bios_print_bit_T(struct envy_bios *, FILE *out, unsigned mask);
 void envy_bios_print_T_unk0(struct envy_bios *, FILE *out, unsigned mask);
+
+int envy_bios_parse_bit_d(struct envy_bios *, struct envy_bios_bit_entry *);
+void envy_bios_print_bit_d(struct envy_bios *, FILE *out, unsigned mask);
 
 int envy_bios_parse_dcb (struct envy_bios *bios);
 void envy_bios_print_dcb (struct envy_bios *bios, FILE *out, unsigned mask);

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -1144,6 +1144,27 @@ struct envy_bios_D {
 	struct envy_bios_D_unk2 unk2;
 };
 
+struct envy_bios_L_unk0_entry {
+	uint16_t offset;
+};
+
+struct envy_bios_L_unk0 {
+	uint16_t offset;
+	uint8_t valid;
+	uint8_t version;
+	uint8_t hlen;
+	uint8_t entriesnum;
+	uint8_t rlen;
+
+	struct envy_bios_L_unk0_entry *entries;
+};
+
+struct envy_bios_L {
+	struct envy_bios_bit_entry *bit;
+
+	struct envy_bios_L_unk0 unk0;
+};
+
 struct envy_bios_block {
 	unsigned int start;
 	unsigned int len;
@@ -1220,6 +1241,7 @@ struct envy_bios {
 	struct envy_bios_power power;
 	struct envy_bios_mem mem;
 	struct envy_bios_D D;
+	struct envy_bios_L L;
 
 	struct envy_bios_block *blocks;
 	int blocksnum;
@@ -1282,6 +1304,7 @@ static inline int bios_string(struct envy_bios *bios, unsigned int offs, char *r
 #define ENVY_BIOS_PRINT_I2CSCRIPT	0x00000800
 #define ENVY_BIOS_PRINT_MEM		0x00001000
 #define ENVY_BIOS_PRINT_D		0x00002000
+#define ENVY_BIOS_PRINT_L		0x00004000
 #define ENVY_BIOS_PRINT_HWSQ		0x00008000
 #define ENVY_BIOS_PRINT_DCB		0x00010000
 #define ENVY_BIOS_PRINT_GPIO		0x00020000
@@ -1348,6 +1371,9 @@ int envy_bios_parse_bit_D (struct envy_bios *, struct envy_bios_bit_entry *);
 void envy_bios_print_bit_D (struct envy_bios *, FILE *out, unsigned mask);
 void envy_bios_print_d_unk0(struct envy_bios *, FILE *out, unsigned mask);
 void envy_bios_print_d_unk2(struct envy_bios *, FILE *out, unsigned mask);
+
+int envy_bios_parse_bit_L(struct envy_bios *, struct envy_bios_bit_entry *);
+void envy_bios_print_bit_L(struct envy_bios *, FILE *out, unsigned mask);
 
 int envy_bios_parse_dcb (struct envy_bios *bios);
 void envy_bios_print_dcb (struct envy_bios *bios, FILE *out, unsigned mask);

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -1165,6 +1165,27 @@ struct envy_bios_L {
 	struct envy_bios_L_unk0 unk0;
 };
 
+struct envy_bios_T_unk0_entry {
+	uint16_t offset;
+};
+
+struct envy_bios_T_unk0 {
+	uint16_t offset;
+	uint8_t valid;
+	uint8_t version;
+	uint8_t hlen;
+	uint8_t entriesnum;
+	uint8_t rlen;
+
+	struct envy_bios_T_unk0_entry *entries;
+};
+
+struct envy_bios_T {
+	struct envy_bios_bit_entry *bit;
+
+	struct envy_bios_T_unk0 unk0;
+};
+
 struct envy_bios_block {
 	unsigned int start;
 	unsigned int len;
@@ -1242,6 +1263,7 @@ struct envy_bios {
 	struct envy_bios_mem mem;
 	struct envy_bios_D D;
 	struct envy_bios_L L;
+	struct envy_bios_T T;
 
 	struct envy_bios_block *blocks;
 	int blocksnum;
@@ -1314,6 +1336,7 @@ static inline int bios_string(struct envy_bios *bios, unsigned int offs, char *r
 #define ENVY_BIOS_PRINT_MUX		0x00200000
 #define ENVY_BIOS_PRINT_DUNK		0x00400000
 #define ENVY_BIOS_PRINT_DCB_ALL		0x007f0000
+#define ENVY_BIOS_PRINT_T		0x00800000
 #define ENVY_BIOS_PRINT_ALL		0x1fffffff
 #define ENVY_BIOS_PRINT_BLOCKS		0x20000000
 #define ENVY_BIOS_PRINT_UNUSED		0x40000000
@@ -1375,6 +1398,9 @@ void envy_bios_print_d_unk2(struct envy_bios *, FILE *out, unsigned mask);
 int envy_bios_parse_bit_L(struct envy_bios *, struct envy_bios_bit_entry *);
 void envy_bios_print_bit_L(struct envy_bios *, FILE *out, unsigned mask);
 void envy_bios_print_L_unk0(struct envy_bios *, FILE *out, unsigned mask);
+
+int envy_bios_parse_bit_T(struct envy_bios *, struct envy_bios_bit_entry *);
+void envy_bios_print_bit_T(struct envy_bios *, FILE *out, unsigned mask);
 
 int envy_bios_parse_dcb (struct envy_bios *bios);
 void envy_bios_print_dcb (struct envy_bios *bios, FILE *out, unsigned mask);

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -1346,6 +1346,7 @@ void envy_bios_print_mem_type(struct envy_bios *bios, FILE *out, unsigned mask);
 
 int envy_bios_parse_bit_D (struct envy_bios *, struct envy_bios_bit_entry *);
 void envy_bios_print_bit_D (struct envy_bios *, FILE *out, unsigned mask);
+void envy_bios_print_d_unk0(struct envy_bios *, FILE *out, unsigned mask);
 void envy_bios_print_d_unk2(struct envy_bios *, FILE *out, unsigned mask);
 
 int envy_bios_parse_dcb (struct envy_bios *bios);

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -1107,6 +1107,43 @@ struct envy_bios_power {
 	struct envy_bios_power_unk64 unk64;
 };
 
+struct envy_bios_D_unk0_entry {
+	uint16_t offset;
+};
+
+struct envy_bios_D_unk0 {
+	uint16_t offset;
+	uint8_t valid;
+	uint8_t version;
+	uint8_t hlen;
+	uint8_t entriesnum;
+	uint8_t rlen;
+
+	struct envy_bios_D_unk0_entry *entries;
+};
+
+struct envy_bios_D_unk2_entry {
+	uint16_t offset;
+};
+
+struct envy_bios_D_unk2 {
+	uint16_t offset;
+	uint8_t valid;
+	uint8_t version;
+	uint8_t hlen;
+	uint8_t entriesnum;
+	uint8_t rlen;
+
+	struct envy_bios_D_unk2_entry *entries;
+};
+
+struct envy_bios_D {
+	struct envy_bios_bit_entry *bit;
+
+	struct envy_bios_D_unk0 unk0;
+	struct envy_bios_D_unk2 unk2;
+};
+
 struct envy_bios_block {
 	unsigned int start;
 	unsigned int len;
@@ -1182,6 +1219,7 @@ struct envy_bios {
 	struct envy_bios_mux mux;
 	struct envy_bios_power power;
 	struct envy_bios_mem mem;
+	struct envy_bios_D D;
 
 	struct envy_bios_block *blocks;
 	int blocksnum;
@@ -1243,6 +1281,7 @@ static inline int bios_string(struct envy_bios *bios, unsigned int offs, char *r
 #define ENVY_BIOS_PRINT_PERF		0x00000400
 #define ENVY_BIOS_PRINT_I2CSCRIPT	0x00000800
 #define ENVY_BIOS_PRINT_MEM		0x00001000
+#define ENVY_BIOS_PRINT_D		0x00002000
 #define ENVY_BIOS_PRINT_HWSQ		0x00008000
 #define ENVY_BIOS_PRINT_DCB		0x00010000
 #define ENVY_BIOS_PRINT_GPIO		0x00020000
@@ -1304,6 +1343,9 @@ void envy_bios_print_bit_M (struct envy_bios *bios, FILE *out, unsigned mask);
 void envy_bios_print_mem_train(struct envy_bios *bios, FILE *out, unsigned mask);
 void envy_bios_print_mem_train_ptrn(struct envy_bios *bios, FILE *out, unsigned mask);
 void envy_bios_print_mem_type(struct envy_bios *bios, FILE *out, unsigned mask);
+
+int envy_bios_parse_bit_D (struct envy_bios *, struct envy_bios_bit_entry *);
+void envy_bios_print_bit_D (struct envy_bios *, FILE *out, unsigned mask);
 
 int envy_bios_parse_dcb (struct envy_bios *bios);
 void envy_bios_print_dcb (struct envy_bios *bios, FILE *out, unsigned mask);

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -1374,6 +1374,7 @@ void envy_bios_print_d_unk2(struct envy_bios *, FILE *out, unsigned mask);
 
 int envy_bios_parse_bit_L(struct envy_bios *, struct envy_bios_bit_entry *);
 void envy_bios_print_bit_L(struct envy_bios *, FILE *out, unsigned mask);
+void envy_bios_print_L_unk0(struct envy_bios *, FILE *out, unsigned mask);
 
 int envy_bios_parse_dcb (struct envy_bios *bios);
 void envy_bios_print_dcb (struct envy_bios *bios, FILE *out, unsigned mask);

--- a/nvbios/bit.c
+++ b/nvbios/bit.c
@@ -47,6 +47,7 @@ static const struct {
 	{ 'M', 1, envy_bios_parse_bit_M },	/* Mem v1 */
 	{ 'M', 2, envy_bios_parse_bit_M },	/* Mem v2 */
 	{ 'D', 1, envy_bios_parse_bit_D },	/* D? */
+	{ 'L', 1, envy_bios_parse_bit_L },	/* L? */
 	{ 0 },
 };
 

--- a/nvbios/bit.c
+++ b/nvbios/bit.c
@@ -49,6 +49,7 @@ static const struct {
 	{ 'D', 1, envy_bios_parse_bit_D },	/* D? */
 	{ 'L', 1, envy_bios_parse_bit_L },	/* L? */
 	{ 'T', 1, envy_bios_parse_bit_T },	/* T? */
+	{ 'd', 1, envy_bios_parse_bit_d },	/* d? */
 	{ 0 },
 };
 

--- a/nvbios/bit.c
+++ b/nvbios/bit.c
@@ -48,6 +48,7 @@ static const struct {
 	{ 'M', 2, envy_bios_parse_bit_M },	/* Mem v2 */
 	{ 'D', 1, envy_bios_parse_bit_D },	/* D? */
 	{ 'L', 1, envy_bios_parse_bit_L },	/* L? */
+	{ 'T', 1, envy_bios_parse_bit_T },	/* T? */
 	{ 0 },
 };
 

--- a/nvbios/bit.c
+++ b/nvbios/bit.c
@@ -46,6 +46,7 @@ static const struct {
 	{ 'P', 2, envy_bios_parse_bit_P },	/* Power v2 */
 	{ 'M', 1, envy_bios_parse_bit_M },	/* Mem v1 */
 	{ 'M', 2, envy_bios_parse_bit_M },	/* Mem v2 */
+	{ 'D', 1, envy_bios_parse_bit_D },	/* D? */
 	{ 0 },
 };
 

--- a/nvbios/d.c
+++ b/nvbios/d.c
@@ -24,6 +24,8 @@
 
 #include "bios.h"
 
+static void envy_bios_parse_d_unk0(struct envy_bios *);
+
 struct d_known_tables {
 	uint8_t offset;
 	uint16_t *ptr;
@@ -35,7 +37,7 @@ parse_at(struct envy_bios *bios, unsigned int idx, const char **name)
 {
 	struct envy_bios_d *d = &bios->d;
 	struct d_known_tables tbls[] = {
-		{ 0x0, &d->unk0.offset, "UNK0 TABLE" },
+		{ 0x0, &d->unk0.offset, "UNK0 SCRIPT TABLE" },
 	};
 	int entries_count = (sizeof(tbls) / sizeof(struct d_known_tables));
 
@@ -65,6 +67,7 @@ envy_bios_parse_bit_d(struct envy_bios *bios, struct envy_bios_bit_entry *bit)
 		idx++;
 
 	/* parse tables */
+	envy_bios_parse_d_unk0(bios);
 
 	return 0;
 }
@@ -89,6 +92,61 @@ envy_bios_print_bit_d(struct envy_bios *bios, FILE *out, unsigned mask)
 			ret = parse_at(bios, i, &name);
 			fprintf(out, "0x%02x: 0x%x => V %s\n", i * 2, addr, name);
 		}
+	}
+
+	fprintf(out, "\n");
+}
+
+static void
+envy_bios_parse_d_unk0(struct envy_bios *bios)
+{
+	struct envy_bios_d_unk0 *unk0 = &bios->d.unk0;
+	int err = 0, i;
+
+	if (!unk0->offset)
+		return;
+
+	bios_u8(bios, unk0->offset, &unk0->version);
+	switch (unk0->version) {
+	case 0x40:
+		err |= bios_u8(bios, unk0->offset + 0x1, &unk0->hlen);
+		err |= bios_u8(bios, unk0->offset + 0x2, &unk0->rlen);
+		err |= bios_u8(bios, unk0->offset + 0x3, &unk0->entriesnum);
+		unk0->valid = !err;
+		break;
+	default:
+		ENVY_BIOS_ERR("Unknown V UNK0 table version 0x%x\n", unk0->version);
+		return;
+	}
+
+	unk0->entries = malloc(unk0->entriesnum * sizeof(struct envy_bios_d_unk0_entry));
+	for (i = 0; i < unk0->entriesnum; ++i) {
+		struct envy_bios_d_unk0_entry *e = &unk0->entries[i];
+		e->offset = unk0->offset + unk0->hlen + i * unk0->rlen;
+	}
+}
+
+void
+envy_bios_print_V_unk0(struct envy_bios *bios, FILE *out, unsigned mask)
+{
+	struct envy_bios_d_unk0 *unk0 = &bios->d.unk0;
+	int i;
+
+	if (!unk0->offset || !(mask & ENVY_BIOS_PRINT_d))
+		return;
+	if (!unk0->valid) {
+		ENVY_BIOS_ERR("Failed to parse d UNK0 table at 0x%x, version %x\n\n", unk0->offset, unk0->version);
+		return;
+	}
+
+	fprintf(out, "d UNK0 SCRIPT table at 0x%x, version %x\n", unk0->offset, unk0->version);
+	envy_bios_dump_hex(bios, out, unk0->offset, unk0->hlen, mask);
+	if (mask & ENVY_BIOS_PRINT_VERBOSE) fprintf(out, "\n");
+
+	for (i = 0; i < unk0->entriesnum; ++i) {
+		struct envy_bios_d_unk0_entry *e = &unk0->entries[i];
+		envy_bios_dump_hex(bios, out, e->offset, unk0->rlen, mask);
+		if (mask & ENVY_BIOS_PRINT_VERBOSE) fprintf(out, "\n");
 	}
 
 	fprintf(out, "\n");

--- a/nvbios/d.c
+++ b/nvbios/d.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2016 Karol Herbst
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "bios.h"
+
+struct d_known_tables {
+	uint8_t offset;
+	uint16_t *ptr;
+	const char *name;
+};
+
+static int
+parse_at(struct envy_bios *bios, unsigned int idx, const char **name)
+{
+	struct envy_bios_d *d = &bios->d;
+	struct d_known_tables tbls[] = {
+		{ 0x0, &d->unk0.offset, "UNK0 TABLE" },
+	};
+	int entries_count = (sizeof(tbls) / sizeof(struct d_known_tables));
+
+	/* check the index */
+	if (idx >= entries_count)
+		return -ENOENT;
+
+	/* check the table has the right size */
+	if (tbls[idx].offset + 2 > d->bit->t_len)
+		return -ENOENT;
+
+	if (name)
+		*name = tbls[idx].name;
+
+	return bios_u16(bios, d->bit->t_offset + tbls[idx].offset, tbls[idx].ptr);
+}
+
+int
+envy_bios_parse_bit_d(struct envy_bios *bios, struct envy_bios_bit_entry *bit)
+{
+	struct envy_bios_d *d = &bios->d;
+	unsigned int idx = 0;
+
+	d->bit = bit;
+
+	while (!parse_at(bios, idx, NULL))
+		idx++;
+
+	/* parse tables */
+
+	return 0;
+}
+
+void
+envy_bios_print_bit_d(struct envy_bios *bios, FILE *out, unsigned mask)
+{
+	struct envy_bios_d *d = &bios->d;
+	uint16_t addr;
+	int ret = 0, i = 0;
+
+	if (!d->bit || !(mask & ENVY_BIOS_PRINT_d))
+		return;
+
+	fprintf(out, "BIT table 'V' at 0x%x, version %i\n",
+		d->bit->offset, d->bit->version);
+
+	for (i = 0; i * 2 < d->bit->t_len; ++i) {
+		ret = bios_u16(bios, d->bit->t_offset + (i * 2), &addr);
+		if (!ret && addr) {
+			const char *name;
+			ret = parse_at(bios, i, &name);
+			fprintf(out, "0x%02x: 0x%x => V %s\n", i * 2, addr, name);
+		}
+	}
+
+	fprintf(out, "\n");
+}

--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -93,6 +93,7 @@ struct {
 	{ "mem",	ENVY_BIOS_PRINT_MEM },
 	{ "ram",	ENVY_BIOS_PRINT_RAM },
 	{ "perf",	ENVY_BIOS_PRINT_PERF },
+	{ "D",		ENVY_BIOS_PRINT_D },
 	{ "i2cscript",	ENVY_BIOS_PRINT_I2CSCRIPT },
 	{ "dcball",	ENVY_BIOS_PRINT_DCB_ALL },
 	{ "dcb",	ENVY_BIOS_PRINT_DCB },

--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -94,6 +94,7 @@ struct {
 	{ "ram",	ENVY_BIOS_PRINT_RAM },
 	{ "perf",	ENVY_BIOS_PRINT_PERF },
 	{ "D",		ENVY_BIOS_PRINT_D },
+	{ "L",		ENVY_BIOS_PRINT_L },
 	{ "i2cscript",	ENVY_BIOS_PRINT_I2CSCRIPT },
 	{ "dcball",	ENVY_BIOS_PRINT_DCB_ALL },
 	{ "dcb",	ENVY_BIOS_PRINT_DCB },

--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -96,6 +96,7 @@ struct {
 	{ "D",		ENVY_BIOS_PRINT_D },
 	{ "L",		ENVY_BIOS_PRINT_L },
 	{ "T",		ENVY_BIOS_PRINT_T },
+	{ "d",		ENVY_BIOS_PRINT_d },
 	{ "i2cscript",	ENVY_BIOS_PRINT_I2CSCRIPT },
 	{ "dcball",	ENVY_BIOS_PRINT_DCB_ALL },
 	{ "dcb",	ENVY_BIOS_PRINT_DCB },

--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -95,6 +95,7 @@ struct {
 	{ "perf",	ENVY_BIOS_PRINT_PERF },
 	{ "D",		ENVY_BIOS_PRINT_D },
 	{ "L",		ENVY_BIOS_PRINT_L },
+	{ "T",		ENVY_BIOS_PRINT_T },
 	{ "i2cscript",	ENVY_BIOS_PRINT_I2CSCRIPT },
 	{ "dcball",	ENVY_BIOS_PRINT_DCB_ALL },
 	{ "dcb",	ENVY_BIOS_PRINT_DCB },

--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -397,6 +397,7 @@ void envy_bios_print (struct envy_bios *bios, FILE *out, unsigned mask) {
 		envy_bios_print_info(bios, stdout, mask);
 		envy_bios_print_bit_P(bios, stdout, mask);
 		envy_bios_print_bit_M(bios, stdout, mask);
+		envy_bios_print_bit_D(bios, stdout, mask);
 
 		envy_bios_print_dacload(bios, stdout, mask);
 		envy_bios_print_iunk21(bios, stdout, mask);

--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -449,6 +449,8 @@ void envy_bios_print (struct envy_bios *bios, FILE *out, unsigned mask) {
 		envy_bios_print_L_unk0(bios, stdout, mask);
 
 		envy_bios_print_T_unk0(bios, stdout, mask);
+
+		envy_bios_print_V_unk0(bios, stdout, mask);
 		break;
 	}
 	if (mask & ENVY_BIOS_PRINT_BLOCKS) {

--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -439,6 +439,8 @@ void envy_bios_print (struct envy_bios *bios, FILE *out, unsigned mask) {
 		envy_bios_print_power_fan_mgmt(bios, stdout, mask);
 		envy_bios_print_power_unk60(bios, stdout, mask);
 		envy_bios_print_power_unk64(bios, stdout, mask);
+
+		envy_bios_print_d_unk2(bios, stdout, mask);
 		break;
 	}
 	if (mask & ENVY_BIOS_PRINT_BLOCKS) {

--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -440,6 +440,7 @@ void envy_bios_print (struct envy_bios *bios, FILE *out, unsigned mask) {
 		envy_bios_print_power_unk60(bios, stdout, mask);
 		envy_bios_print_power_unk64(bios, stdout, mask);
 
+		envy_bios_print_d_unk0(bios, stdout, mask);
 		envy_bios_print_d_unk2(bios, stdout, mask);
 		break;
 	}

--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -400,6 +400,7 @@ void envy_bios_print (struct envy_bios *bios, FILE *out, unsigned mask) {
 		envy_bios_print_bit_D(bios, stdout, mask);
 		envy_bios_print_bit_L(bios, stdout, mask);
 		envy_bios_print_bit_T(bios, stdout, mask);
+		envy_bios_print_bit_d(bios, stdout, mask);
 
 		envy_bios_print_dacload(bios, stdout, mask);
 		envy_bios_print_iunk21(bios, stdout, mask);

--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -399,6 +399,7 @@ void envy_bios_print (struct envy_bios *bios, FILE *out, unsigned mask) {
 		envy_bios_print_bit_M(bios, stdout, mask);
 		envy_bios_print_bit_D(bios, stdout, mask);
 		envy_bios_print_bit_L(bios, stdout, mask);
+		envy_bios_print_bit_T(bios, stdout, mask);
 
 		envy_bios_print_dacload(bios, stdout, mask);
 		envy_bios_print_iunk21(bios, stdout, mask);

--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -443,6 +443,8 @@ void envy_bios_print (struct envy_bios *bios, FILE *out, unsigned mask) {
 
 		envy_bios_print_d_unk0(bios, stdout, mask);
 		envy_bios_print_d_unk2(bios, stdout, mask);
+
+		envy_bios_print_L_unk0(bios, stdout, mask);
 		break;
 	}
 	if (mask & ENVY_BIOS_PRINT_BLOCKS) {

--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -446,6 +446,8 @@ void envy_bios_print (struct envy_bios *bios, FILE *out, unsigned mask) {
 		envy_bios_print_d_unk2(bios, stdout, mask);
 
 		envy_bios_print_L_unk0(bios, stdout, mask);
+
+		envy_bios_print_T_unk0(bios, stdout, mask);
 		break;
 	}
 	if (mask & ENVY_BIOS_PRINT_BLOCKS) {

--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -398,6 +398,7 @@ void envy_bios_print (struct envy_bios *bios, FILE *out, unsigned mask) {
 		envy_bios_print_bit_P(bios, stdout, mask);
 		envy_bios_print_bit_M(bios, stdout, mask);
 		envy_bios_print_bit_D(bios, stdout, mask);
+		envy_bios_print_bit_L(bios, stdout, mask);
 
 		envy_bios_print_dacload(bios, stdout, mask);
 		envy_bios_print_iunk21(bios, stdout, mask);


### PR DESCRIPTION
Those fields are clearly tables and we should dump them with nvbios -v so that they get displayed.
