### PR TITLE
Improve parsing of SENSE table

### DIFF
--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -856,13 +856,27 @@ struct envy_bios_power_unk24 {
 	struct envy_bios_power_unk24_entry *entries;
 };
 
+struct envy_bios_power_sense_resistor {
+	uint8_t mohm;
+	uint8_t unk;
+};
+
 struct envy_bios_power_sense_entry {
 	uint32_t offset;
 	uint8_t mode;
 	uint8_t extdev_id;
-	uint8_t resistor_mohm;
-	uint8_t rail;
-	uint16_t config;
+
+	union {
+		struct {
+			struct envy_bios_power_sense_resistor res;
+			uint16_t config;
+		} ina219;
+		struct {
+			struct envy_bios_power_sense_resistor res[3];
+			uint16_t config;
+		} ina3221;
+		uint8_t raw[0x10];
+	} d;
 };
 
 struct envy_bios_power_sense {


### PR DESCRIPTION
This should be very close to what nvidia does. There are some more unknown bytes I don't quite understand, but they are less important and usually set to 00 anyway.

I am sure that those unknowns bytes are partly related to the power budgets, but this will be taken care of later.
