### PR TITLE
nvbios: 32bit table offsets

### DIFF
--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -698,15 +698,15 @@ struct envy_bios_mem {
 };
 
 struct envy_bios_power_volt {
-	uint16_t offset;
+	uint32_t offset;
 };
 
 struct envy_bios_power_unk14_entry {
-	uint16_t offset;
+	uint32_t offset;
 };
 
 struct envy_bios_power_unk14 {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint8_t version;
 	uint8_t hlen;
@@ -717,11 +717,11 @@ struct envy_bios_power_unk14 {
 };
 
 struct envy_bios_power_unk18_entry {
-	uint16_t offset;
+	uint32_t offset;
 };
 
 struct envy_bios_power_unk18 {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint8_t version;
 	uint8_t hlen;
@@ -732,36 +732,36 @@ struct envy_bios_power_unk18 {
 };
 
 struct envy_bios_power_unk1c_entry {
-	uint16_t offset;
+	uint32_t offset;
 };
 
 struct envy_bios_power_unk1c {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t version;
 };
 
 struct envy_bios_power_volt_map {
-	uint16_t offset;
+	uint32_t offset;
 };
 
 struct envy_bios_power_perf {
-	uint16_t offset;
+	uint32_t offset;
 };
 
 struct envy_bios_power_therm {
-	uint16_t offset;
+	uint32_t offset;
 };
 
 struct envy_bios_power_timing {
-	uint16_t offset;
+	uint32_t offset;
 };
 
 struct envy_bios_power_timing_map {
-	uint16_t offset;
+	uint32_t offset;
 };
 
 struct envy_bios_power_boost_subentry {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t domain;
 	uint8_t percent;
 	uint16_t min;
@@ -769,7 +769,7 @@ struct envy_bios_power_boost_subentry {
 };
 
 struct envy_bios_power_boost_entry {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t pstate;
 	uint16_t min;
 	uint16_t max;
@@ -777,7 +777,7 @@ struct envy_bios_power_boost_entry {
 };
 
 struct envy_bios_power_boost {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint8_t version;
 	uint8_t hlen;
@@ -789,13 +789,13 @@ struct envy_bios_power_boost {
 };
 
 struct envy_bios_power_cstep_entry1 {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t pstate;
 	uint8_t index;
 };
 
 struct envy_bios_power_cstep_entry2 {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint16_t freq;
 	uint8_t unkn[2];
@@ -803,7 +803,7 @@ struct envy_bios_power_cstep_entry2 {
 };
 
 struct envy_bios_power_cstep {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint8_t version;
 	uint8_t hlen;
@@ -816,7 +816,7 @@ struct envy_bios_power_cstep {
 };
 
 struct envy_bios_power_budget_entry {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 
 	uint32_t min;
@@ -826,7 +826,7 @@ struct envy_bios_power_budget_entry {
 };
 
 struct envy_bios_power_budget {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint8_t version;
 	uint8_t hlen;
@@ -839,11 +839,11 @@ struct envy_bios_power_budget {
 };
 
 struct envy_bios_power_unk24_entry {
-	uint16_t offset;
+	uint32_t offset;
 };
 
 struct envy_bios_power_unk24 {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint8_t version;
 	uint8_t hlen;
@@ -854,7 +854,7 @@ struct envy_bios_power_unk24 {
 };
 
 struct envy_bios_power_sense_entry {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t mode;
 	uint8_t extdev_id;
 	uint8_t resistor_mohm;
@@ -863,7 +863,7 @@ struct envy_bios_power_sense_entry {
 };
 
 struct envy_bios_power_sense {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint8_t version;
 	uint8_t hlen;
@@ -874,7 +874,7 @@ struct envy_bios_power_sense {
 };
 
 struct envy_bios_power_base_clock_entry {
-	uint16_t offset;
+	uint32_t offset;
 
 	uint8_t pstate;
 	uint16_t unk0;
@@ -883,7 +883,7 @@ struct envy_bios_power_base_clock_entry {
 };
 
 struct envy_bios_power_base_clock {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint8_t version;
 
@@ -901,11 +901,11 @@ struct envy_bios_power_base_clock {
 };
 
 struct envy_bios_power_unk3c_entry {
-	uint16_t offset;
+	uint32_t offset;
 };
 
 struct envy_bios_power_unk3c {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint8_t version;
 	uint8_t hlen;
@@ -916,11 +916,11 @@ struct envy_bios_power_unk3c {
 };
 
 struct envy_bios_power_unk40_entry {
-	uint16_t offset;
+	uint32_t offset;
 };
 
 struct envy_bios_power_unk40 {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint8_t version;
 	uint8_t hlen;
@@ -931,18 +931,18 @@ struct envy_bios_power_unk40 {
 };
 
 struct envy_bios_power_unk44 {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint8_t version;
 	uint8_t hlen;
 };
 
 struct envy_bios_power_unk48_entry {
-	uint16_t offset;
+	uint32_t offset;
 };
 
 struct envy_bios_power_unk48 {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint8_t version;
 	uint8_t hlen;
@@ -953,11 +953,11 @@ struct envy_bios_power_unk48 {
 };
 
 struct envy_bios_power_unk4c_entry {
-	uint16_t offset;
+	uint32_t offset;
 };
 
 struct envy_bios_power_unk4c {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint8_t version;
 	uint8_t hlen;
@@ -968,7 +968,7 @@ struct envy_bios_power_unk4c {
 };
 
 struct envy_bios_power_unk50_entry {
-	uint16_t offset;
+	uint32_t offset;
 
 	uint8_t  mode;
 	uint16_t downclock_t;
@@ -978,7 +978,7 @@ struct envy_bios_power_unk50_entry {
 };
 
 struct envy_bios_power_unk50 {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint8_t version;
 	uint8_t hlen;
@@ -989,11 +989,11 @@ struct envy_bios_power_unk50 {
 };
 
 struct envy_bios_power_unk54_entry {
-	uint16_t offset;
+	uint32_t offset;
 };
 
 struct envy_bios_power_unk54 {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint8_t version;
 	uint8_t hlen;
@@ -1004,7 +1004,7 @@ struct envy_bios_power_unk54 {
 };
 
 struct envy_bios_power_fan {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint8_t version;
 	uint8_t hlen;
@@ -1022,7 +1022,7 @@ struct envy_bios_power_fan {
 };
 
 struct envy_bios_power_fan_mgmt_entry {
-	uint16_t offset;
+	uint32_t offset;
 
 	uint8_t  duty0;
 	uint16_t temp0;
@@ -1038,7 +1038,7 @@ struct envy_bios_power_fan_mgmt_entry {
 };
 
 struct envy_bios_power_fan_mgmt {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint8_t version;
 	uint8_t hlen;
@@ -1049,11 +1049,11 @@ struct envy_bios_power_fan_mgmt {
 };
 
 struct envy_bios_power_unk60_entry {
-	uint16_t offset;
+	uint32_t offset;
 };
 
 struct envy_bios_power_unk60 {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint8_t version;
 	uint8_t hlen;
@@ -1064,11 +1064,11 @@ struct envy_bios_power_unk60 {
 };
 
 struct envy_bios_power_unk64_entry {
-	uint16_t offset;
+	uint32_t offset;
 };
 
 struct envy_bios_power_unk64 {
-	uint16_t offset;
+	uint32_t offset;
 	uint8_t valid;
 	uint8_t version;
 	uint8_t hlen;

--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -1396,7 +1396,7 @@ int main(int argc, char **argv) {
 		uint8_t mode_info_length = 0, header_length = 0;
 		uint8_t extra_data_length = 8, extra_data_count = 0;
 		uint8_t subentry_offset = 0, subentry_size = 0, subentry_count = 0;
-		uint16_t start = bios->power.perf.offset;
+		uint32_t start = bios->power.perf.offset;
 		uint16_t id = 0, core_mask = 0;
 		uint8_t ram_cfg = strap?(strap & 0x1c) >> 2:0xff;
 		char sub_entry_engine[16][11] = { "unk" };
@@ -1637,7 +1637,7 @@ int main(int argc, char **argv) {
 	if (bios->power.volt_map.offset && (printmask & ENVY_BIOS_PRINT_PERF)) {
 		uint8_t version = 0, entry_count = 0, entry_length = 0;
 		uint8_t header_length = 0;
-		uint16_t start = bios->power.volt_map.offset;
+		uint32_t start = bios->power.volt_map.offset;
 
 		version = bios->data[start+0];
 		header_length = bios->data[start+1];
@@ -1730,7 +1730,7 @@ int main(int argc, char **argv) {
 		uint8_t version = 0, entry_count = 0, entry_length = 0;
 		uint8_t header_length = 0, mask = 0, is_pwm_based = 0;
 		uint8_t gpio_use_header = 0;
-		uint16_t start = bios->power.volt.offset;
+		uint32_t start = bios->power.volt.offset;
 		int16_t step_uv = 0;
 		uint32_t volt_uv = 0, volt;
 		uint8_t shift = 0;
@@ -2042,7 +2042,7 @@ int main(int argc, char **argv) {
 	if (bios->power.timing.offset && (printmask & ENVY_BIOS_PRINT_PERF)) {
 		uint8_t version = 0, entry_count = 0, entry_length = 0;
 		uint8_t header_length = 0;
-		uint16_t start = bios->power.timing.offset;
+		uint32_t start = bios->power.timing.offset;
 		uint8_t tWR, tWTR, tCL;
 		uint8_t tRC;		/* Byte 3 */
 		uint8_t tRFC;	/* Byte 5 */
@@ -2224,7 +2224,7 @@ int main(int argc, char **argv) {
 		uint8_t 	version = 0, entry_count = 0, entry_length = 0,
 				xinfo_count = 0, xinfo_length = 0,
 				header_length = 0;
-		uint16_t start = bios->power.timing_map.offset;
+		uint32_t start = bios->power.timing_map.offset;
 		uint16_t clock_low = 0, clock_hi = 0;
 		uint16_t entry;
 		int j;

--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -129,8 +129,8 @@ void printhex (uint32_t start, uint32_t length) {
 	envy_bios_dump_hex(bios, stdout, start, length, printmask);
 }
 
-void printcmd (uint16_t off, uint16_t length) {
-	printf ("0x%04x:", off);
+void printcmd (uint32_t off, uint32_t length) {
+	printf ("0x%08x:", off);
 	int i;
 	for (i = 0; i < length; i++)
 		printf(" %02x", bios->data[off+i]);
@@ -138,11 +138,11 @@ void printcmd (uint16_t off, uint16_t length) {
 		printf ("   ");
 }
 
-uint32_t le32 (uint16_t off) {
+uint32_t le32 (uint32_t off) {
 	return bios->data[off] | bios->data[off+1] << 8 | bios->data[off+2] << 16 | bios->data[off+3] << 24;
 }
 
-uint16_t le16 (uint16_t off) {
+uint16_t le16 (uint32_t off) {
 	return bios->data[off] | bios->data[off+1] << 8;
 }
 

--- a/nvbios/power.c
+++ b/nvbios/power.c
@@ -52,7 +52,7 @@ int envy_bios_parse_power_unk64(struct envy_bios *bios);
 
 struct P_known_tables {
 	uint8_t offset;
-	uint16_t *ptr;
+	uint32_t *ptr;
 	const char *name;
 };
 
@@ -96,6 +96,7 @@ static int parse_at(struct envy_bios *bios, struct envy_bios_power *power,
 	};
 	struct P_known_tables *tbls;
 	int entries_count = 0;
+	int ret;
 
 	if (power->bit->version == 0x1) {
 		tbls = p1_tbls;
@@ -120,17 +121,18 @@ static int parse_at(struct envy_bios *bios, struct envy_bios_power *power,
 	/* check the index */
 	if (idx < 0 || idx >= entries_count)
 		return -ENOENT;
-	
+
 	/* check the table has the right size */
 	if (tbls[idx].offset + 2 > power->bit->t_len)
 		return -ENOENT;
-	
+
 	if (name)
 		*name = tbls[idx].name;
-	
-	return bios_u16(bios, 
-			power->bit->t_offset + tbls[idx].offset, 
-			tbls[idx].ptr);
+
+	uint32_t tblOffset;
+	ret = bios_u32(bios, power->bit->t_offset + tbls[idx].offset, &tblOffset);
+	*tbls[idx].ptr = tblOffset;
+	return ret;
 }
 
 int envy_bios_parse_bit_P (struct envy_bios *bios, struct envy_bios_bit_entry *bit) {

--- a/nvbios/power.c
+++ b/nvbios/power.c
@@ -170,7 +170,7 @@ int envy_bios_parse_bit_P (struct envy_bios *bios, struct envy_bios_bit_entry *b
 void envy_bios_print_bit_P (struct envy_bios *bios, FILE *out, unsigned mask) {
 	struct envy_bios_power *power = &bios->power;
 	const char *name;
-	uint16_t addr;
+	uint32_t addr;
 	int ret = 0, i = 0;
 	
 	if (!power->bit || !(mask & ENVY_BIOS_PRINT_PERF))
@@ -179,8 +179,8 @@ void envy_bios_print_bit_P (struct envy_bios *bios, FILE *out, unsigned mask) {
 	fprintf(out, "BIT table 'P' at 0x%x, version %i\n", 
 		power->bit->offset, power->bit->version);
 
-	for (i = 0; i < power->bit->t_len; i+=2) {
-		ret = bios_u16(bios, power->bit->t_offset + i, &addr);
+	for (i = 0; i < power->bit->t_len; i+=4) {
+		ret = bios_u32(bios, power->bit->t_offset + i, &addr);
 		if (!ret && addr) {
 			name = "UNKNOWN";
 			ret = parse_at(bios, power, -1, i, &name);
@@ -354,7 +354,7 @@ int envy_bios_parse_power_boost(struct envy_bios *bios) {
 	boost->entries = malloc(boost->entriesnum * sizeof(struct envy_bios_power_boost_entry));
 
 	for (i = 0; i < boost->entriesnum; i++) {
-		uint16_t data = boost->offset + boost->hlen + i * (boost->rlen + (boost->snr * boost->ssz));
+		uint32_t data = boost->offset + boost->hlen + i * (boost->rlen + (boost->snr * boost->ssz));
 
 		uint16_t tmp;
 		err |= bios_u16(bios, data + 0x0, &tmp);
@@ -368,7 +368,7 @@ int envy_bios_parse_power_boost(struct envy_bios *bios) {
 
 		for (j = 0; j < boost->snr; j++) {
 			struct envy_bios_power_boost_subentry *sub = &boost->entries[i].entries[j];
-			uint16_t sdata = data + boost->rlen + j * boost->ssz;
+			uint32_t sdata = data + boost->rlen + j * boost->ssz;
 
 			sub->offset = sdata;
 			bios_u8(bios, sdata + 0x0, &sub->domain);
@@ -440,7 +440,7 @@ int envy_bios_parse_power_cstep(struct envy_bios *bios) {
 
 	assert(cstep->entriesnum <= (sizeof(cstep->ent1) / sizeof(struct envy_bios_power_cstep_entry1)));
 	for (i = 0; i < cstep->entriesnum; i++) {
-		uint16_t data = cstep->offset + cstep->hlen + i * cstep->rlen;
+		uint32_t data = cstep->offset + cstep->hlen + i * cstep->rlen;
 
 		uint16_t tmp;
 		err |= bios_u16(bios, data + 0x0, &tmp);
@@ -453,7 +453,7 @@ int envy_bios_parse_power_cstep(struct envy_bios *bios) {
 	cstep->ent2 = malloc(cstep->snr * sizeof(struct envy_bios_power_cstep_entry2));
 	memset(cstep->ent2, 0x0, cstep->snr * sizeof(struct envy_bios_power_cstep_entry2));
 	for (i = 0; i < cstep->snr; i++) {
-		uint16_t data = cstep->offset + cstep->hlen + (cstep->entriesnum * cstep->rlen) + (i * cstep->ssz);
+		uint32_t data = cstep->offset + cstep->hlen + (cstep->entriesnum * cstep->rlen) + (i * cstep->ssz);
 
 		cstep->ent2[i].offset = data;
 		bios_u16(bios, data + 0x0, &cstep->ent2[i].freq);
@@ -1153,7 +1153,7 @@ int envy_bios_parse_power_unk54(struct envy_bios *bios) {
 	err = 0;
 	unk54->entries = malloc(unk54->entriesnum * sizeof(struct envy_bios_power_unk54_entry));
 	for (i = 0; i < unk54->entriesnum; i++) {
-		uint16_t data = unk54->offset + unk54->hlen + i * unk54->rlen;
+		uint32_t data = unk54->offset + unk54->hlen + i * unk54->rlen;
 
 		unk54->entries[i].offset = data;
 	}

--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -65,7 +65,7 @@ void envy_bios_dump_hex (struct envy_bios *bios, FILE *out, unsigned int start, 
 		while (length) {
 			unsigned int i, len = length;
 			if (len > 16) len = 16;
-			fprintf (out, "0x%04x:", start);
+			fprintf (out, "0x%08x:", start);
 			for (i = 0; i < len; i++)
 				fprintf(out, " %02x", bios->data[start+i]);
 			fprintf(out, "\n");


### PR DESCRIPTION
@Lekensteyn has a gm204 with a vbios with 32bit table offsets in some P tables. This PR changes the needed bits to at least parse the vbios right. But there will be much more work if we want to change everything