### PR TITLE
use std=c99 and define _GNU_SOURCE globally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ project(ENVYTOOLS C CXX)
 cmake_minimum_required(VERSION 2.6)
 enable_testing()
 
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=c99 -D_GNU_SOURCE")
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 if (NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE "Debug")

--- a/demmt/config.c
+++ b/demmt/config.c
@@ -22,9 +22,6 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-// for gnu version of basename (string.h)
-#define _GNU_SOURCE
-
 #include <fcntl.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/demmt/macro.c
+++ b/demmt/macro.c
@@ -22,8 +22,6 @@
  * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  * OTHER DEALINGS IN THE SOFTWARE.
  */
-#define _GNU_SOURCE
-
 #include "config.h"
 #include "log.h"
 #include "macro.h"

--- a/demmt/pushbuf.c
+++ b/demmt/pushbuf.c
@@ -23,7 +23,6 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#define _GNU_SOURCE
 #include <inttypes.h>
 #include <stdio.h>
 #include <string.h>

--- a/include/util.h
+++ b/include/util.h
@@ -70,15 +70,15 @@ static inline int clog2(uint64_t x) {
 
 #define min(a,b)				\
 	({					\
-		typeof (a) _a = (a);		\
-		typeof (b) _b = (b);		\
+		__typeof__ (a) _a = (a);	\
+		__typeof__ (b) _b = (b);	\
 		_a < _b ? _a : _b;		\
 	})
 
 #define max(a,b)				\
 	({					\
-		typeof (a) _a = (a);		\
-		typeof (b) _b = (b);		\
+		__typeof__ (a) _a = (a);	\
+		__typeof__ (b) _b = (b);	\
 		_a > _b ? _a : _b;		\
 	})
 

--- a/nva/nvaspyi2c.c
+++ b/nva/nvaspyi2c.c
@@ -21,7 +21,6 @@
  * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  * OTHER DEALINGS IN THE SOFTWARE.
  */
-#define _GNU_SOURCE
 #include "nva.h"
 #include <stdio.h>
 #include <stdbool.h>

--- a/rnn/dedma.h
+++ b/rnn/dedma.h
@@ -26,7 +26,6 @@
 #ifndef __DEDMA_H__
 #define __DEDMA_H__
 
-#define _GNU_SOURCE
 #include <errno.h>
 #include <assert.h>
 #include <stdlib.h>

--- a/rnn/lookup.c
+++ b/rnn/lookup.c
@@ -24,7 +24,6 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#define _GNU_SOURCE // for asprintf
 #include "rnn.h"
 #include "rnndec.h"
 #include <stdio.h>

--- a/rnn/rnndec.c
+++ b/rnn/rnndec.c
@@ -23,7 +23,6 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#define _GNU_SOURCE // for asprintf
 #include "rnndec.h"
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
we use c99 features already, so we should explicitly state this. Also define `_GNU_SOURCE` globally, because we use GNU extensions pretty much everywhere.

Also replace `typeof` with `__typeof__`, so that we at least use one extension less.
