### PR TITLE
Add some info on the NV3 and NV4's VESA subsystem

### DIFF
--- a/docs/hw/display/nv3/pcrtc.rst
+++ b/docs/hw/display/nv3/pcrtc.rst
@@ -25,10 +25,11 @@ MMIO registers
    .. todo:: write me
 
 .. space:: 8 prmcio 0x1000 VGA CRTC & attribute controller registers
-
    0x3d0 RMA_ACCESS nv3-io-rma-access
    0x3d4 CRTC_INDEX nv3-io-crtc-index
    0x3d5 CRTC_DATA nv3-io-crtc-data
+
+   .. todo:: complete me
 
 .. _pcrtc-intr:
 
@@ -50,7 +51,7 @@ RMA access port
 
 .. reg:: 32 nv3-io-rma-access RMA access port
 
-This is a 32-bit port that writes into the RMA address specified by CRTC register 0x38.
+   This is a 32-bit port that writes into the RMA address specified by CRTC register 0x38.
 
 CRTC registers
 ==============
@@ -60,7 +61,6 @@ CRTC registers
 .. reg:: 8 nv3-io-crtc-data CRTC data
 
 .. space:: 8 nv3-crtc-ext-regs 0x100 Extended VGA registers
-
    0x19 REPAINT_0 nv3-crtc-ext-rpc0
    0x1a REPAINT_1 nv3-crtc-ext-rpc1
    0x1d WRITE_BANK nv3-crtc-ext-write-bank
@@ -74,44 +74,44 @@ CRTC registers
 
 .. reg:: 8 nv3-crtc-ext-rpc0 Extended Start Address and Row Offset
 
-Bits 4-0 are Start Address bits 16-20. Bits 7-5 are Row Offset bits 3-5.
+   Bits 4-0 are Start Address bits 16-20. Bits 7-5 are Row Offset bits 3-5.
 
 .. reg:: 8 nv3-crtc-ext-rpc1 Repaint 1
 
-Bit 2 shifts the row offset either left or right by 1 bit, I forget which way.
+   Bit 2 shifts the row offset either left or right by 1 bit, I forget which way.
 
 .. reg:: 8 nv3-crtc-ext-write-bank Write bank
 
-Write bank for real mode access of the VGA framebuffer in 32k units.
+   Write bank for real mode access of the VGA framebuffer in 32k units.
 
 .. reg:: 8 nv3-crtc-ext-read-bank Read bank
 
-Read bank for real mode access of the VGA framebuffer in 32k units.
+   Read bank for real mode access of the VGA framebuffer in 32k units.
 
 .. reg:: 8 nv3-crtc-ext-extvert Extended Vertical Bits
 
-Bit 0 is Vertical Total bit 10.
-Bit 1 is Vertical Display End bit 10.
-Bit 2 is Vertical Blank Start bit 10.
-Bit 3 is Vertical Sync Start bit 10.
-Bit 4 is Horizontal Total bit 8.
+   Bit 0 is Vertical Total bit 10.
+   Bit 1 is Vertical Display End bit 10.
+   Bit 2 is Vertical Blank Start bit 10.
+   Bit 3 is Vertical Sync Start bit 10.
+   Bit 4 is Horizontal Total bit 8.
 
 .. reg:: 8 nv3-crtc-ext-pixel-fmt Pixel Format
 
-Bits 1-0 are Pixel Format. 0 is VGA, 1 is 8bpp, 2 is 16bpp, and 3 is 32bpp.
+   Bits 1-0 are Pixel Format. 0 is VGA, 1 is 8bpp, 2 is 16bpp, and 3 is 32bpp.
 
 .. reg:: 8 nv3-crtc-ext-exthorz Extended Horizontal Bits
 
-Bit 0 is Horizontal Display End bit 8.
+   Bit 0 is Horizontal Display End bit 8.
 
 .. reg:: 8 nv3-crtc-ext-rmamode RMA mode register
 
-Bit 0 is enable when high, bits 3-1 are which RMA register to write to.
+   Bit 0 enables port 0x3d0 when high, bits 3-1 are which RMA register to write to.
 
 .. reg:: 8 nv3-crtc-ext-i2c-read I2C read register
 
-Bit 3 is SDA, Bit 2 is SCL.
+   Bit 3 is SDA, Bit 2 is SCL.
 
 .. reg:: 8 nv3-crtc-ext-i2c-write I2C write register
 
-Bit 5 is SCL, Bit 4 is SDA.
+   Bit 5 is SCL, Bit 4 is SDA.

--- a/docs/hw/display/nv3/pcrtc.rst
+++ b/docs/hw/display/nv3/pcrtc.rst
@@ -26,8 +26,9 @@ MMIO registers
 
 .. space:: 8 prmcio 0x1000 VGA CRTC & attribute controller registers
 
-   .. todo:: write me
-
+   0x3d0 RMA_ACCESS nv3-io-rma-access
+   0x3d4 CRTC_INDEX nv3-io-crtc-index
+   0x3d5 CRTC_DATA nv3-io-crtc-data
 
 .. _pcrtc-intr:
 
@@ -43,3 +44,74 @@ Vertical/horizontal blanking signals
 ====================================
 
 .. todo:: write me
+
+RMA access port
+===============
+
+.. reg:: 32 nv3-io-rma-access RMA access port
+
+This is a 32-bit port that writes into the RMA address specified by CRTC register 0x38.
+
+CRTC registers
+==============
+
+.. reg:: 8 nv3-io-crtc-index CRTC index
+
+.. reg:: 8 nv3-io-crtc-data CRTC data
+
+.. space:: 8 nv3-crtc-ext-regs 0x100 Extended VGA registers
+
+   0x19 REPAINT_0 nv3-crtc-ext-rpc0
+   0x1a REPAINT_1 nv3-crtc-ext-rpc1
+   0x1d WRITE_BANK nv3-crtc-ext-write-bank
+   0x1e READ_BANK nv3-crtc-ext-read-bank
+   0x25 EXTENDED_VERT nv3-crtc-ext-extvert
+   0x28 PIXEL_FMT nv3-crtc-ext-pixel-fmt
+   0x2d EXTENDED_HORZ nv3-crtc-ext-exthorz
+   0x38 RMA_MODE nv3-crtc-ext-rmamode
+   0x3e I2C_READ nv3-crtc-ext-i2c-read
+   0x3f I2C_WRITE nv3-crtc-ext-i2c-write
+
+.. reg:: 8 nv3-crtc-ext-rpc0 Extended Start Address and Row Offset
+
+Bits 4-0 are Start Address bits 16-20. Bits 7-5 are Row Offset bits 3-5.
+
+.. reg:: 8 nv3-crtc-ext-rpc1 Repaint 1
+
+Bit 2 shifts the row offset either left or right by 1 bit, I forget which way.
+
+.. reg:: 8 nv3-crtc-ext-write-bank Write bank
+
+Write bank for real mode access of the VGA framebuffer in 32k units.
+
+.. reg:: 8 nv3-crtc-ext-read-bank Read bank
+
+Read bank for real mode access of the VGA framebuffer in 32k units.
+
+.. reg:: 8 nv3-crtc-ext-extvert Extended Vertical Bits
+
+Bit 0 is Vertical Total bit 10.
+Bit 1 is Vertical Display End bit 10.
+Bit 2 is Vertical Blank Start bit 10.
+Bit 3 is Vertical Sync Start bit 10.
+Bit 4 is Horizontal Total bit 8.
+
+.. reg:: 8 nv3-crtc-ext-pixel-fmt Pixel Format
+
+Bits 1-0 are Pixel Format. 0 is VGA, 1 is 8bpp, 2 is 16bpp, and 3 is 32bpp.
+
+.. reg:: 8 nv3-crtc-ext-exthorz Extended Horizontal Bits
+
+Bit 0 is Horizontal Display End bit 8.
+
+.. reg:: 8 nv3-crtc-ext-rmamode RMA mode register
+
+Bit 0 is enable when high, bits 3-1 are which RMA register to write to.
+
+.. reg:: 8 nv3-crtc-ext-i2c-read I2C read register
+
+Bit 3 is SDA, Bit 2 is SCL.
+
+.. reg:: 8 nv3-crtc-ext-i2c-write I2C write register
+
+Bit 5 is SCL, Bit 4 is SDA.

--- a/docs/hw/display/nv3/pramdac.rst
+++ b/docs/hw/display/nv3/pramdac.rst
@@ -19,11 +19,19 @@ MMIO registers
 ==============
 
 .. space:: 8 pramdac 0x1000 RAMDAC, video overlay, cursor, and PLL control
-
-   .. todo:: write me
+   0x500 NVPLL nv4-pramdac-nvpll
+   0x504 MPLL nv3-pramdac-mpll
+   0x508 VPLL nv3-pramdac-vpll
+   
+   .. todo:: complete me
 
 .. space:: 8 prmdio 0x1000 VGA DAC registers
 
    .. todo:: write me
 
-.. todo:: write me
+
+.. todo:: complete me
+
+The bit layout for all NV4 PLLs is that bits 18-16 are P, bits 15-8 are N, and bits 7-0 are M.
+
+The clocks are calculated as such: (Crystal frequency * N) / (1 << P) / M.


### PR DESCRIPTION
This information has been verified by running Quake and a VESA tester on an emulator based on it. 1600x1200 doesn't seem to work based on this however, and the values programmed into the CRTC don't make much sense (1856x1200???). I'm thinking it's a bug in the BIOS I'm using to emulate the NV4.