### PR TITLE
nvhw/pgraph: Remove unused variable

### DIFF
--- a/nvhw/pgraph.c
+++ b/nvhw/pgraph.c
@@ -866,7 +866,6 @@ uint32_t nv03_pgraph_rop(struct pgraph_state *state, int x, int y, uint32_t pixe
 			}
 		}
 	}
-	uint32_t ropres;
 	switch (fmt) {
 		case 1:
 			return s.i;


### PR DESCRIPTION
Unused variable 'ropres' in nv03_pgraph_rop() as reported by GCC:

```nvhw/pgraph.c: In function ‘nv03_pgraph_rop’:
nvhw/pgraph.c:869:11: warning: unused variable ‘ropres’ [-Wunused-variable]
  uint32_t ropres;
           ^~~~~~
```
Introduced in: 1c89a5cd58863966119299c13e285d27c3f50a77
