### PR TITLE
nvbios: Rename DP_CONDITION to GENERIC_CONDITION

### DIFF
--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -301,7 +301,7 @@ void printscript (uint16_t soff) {
 				break;
 			case 0x3a:
 				printcmd (soff, 3);
-				printf ("DP_CONDITION\t0x%02x 0x%02x\n", bios->data[soff+1], bios->data[soff+2]);
+				printf ("GENERIC_CONDITION\t0x%02x 0x%02x\n", bios->data[soff+1], bios->data[soff+2]);
 				soff += 3;
 				break;
 			case 0x3b:


### PR DESCRIPTION
Mirrors change made in the drm kernel driver in February 2016.
```
  From 989f57847396d1d042204747985d6aacf5399c8a Mon Sep 17 00:00:00 2001
  From: Ben Skeggs <bskeggs@redhat.com>
  Date: Thu, 18 Feb 2016 04:03:39 +1000
  Subject: [PATCH] drm/nouveau/bios/devinit: rename INIT_DP_CONDITION to
    INIT_GENERIC_CONDITION

  Signed-off-by: Ben Skeggs <bskeggs@redhat.com>
```