### PR TITLE
nvbios: Add support for opcodes 0x47/0x48

### DIFF
--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -314,6 +314,16 @@ void printscript (uint16_t soff) {
 				printf ("IO_OR\t0x03d4[0x%02x] |= 1 << OR\n", bios->data[soff+1]);
 				soff += 2;
 				break;
+			case 0x47:
+				printcmd (soff, 9);
+				printf ("ANDN_REG\tR[0x%06x] &= ~0x%08x\n", le32(soff+1), le32(soff+5));
+				soff += 9;
+				break;
+			case 0x48:
+				printcmd (soff, 9);
+				printf ("OR_REG\tR[0x%06x] |= 0x%08x\n", le32(soff+1), le32(soff+5));
+				soff += 9;
+				break;
 			case 0x49:
 				printcmd (soff, 9);
 				printf ("INDEX_ADDRESS_LATCHED\tR[0x%06x] : R[0x%06x]\n", le32(soff+1), le32(soff+5));


### PR DESCRIPTION
Brings into consistency with the kernel, which has reflected this two opcodes since:
```
  From c79965d8fa275f81af4aa868b01e09c3975127a3 Mon Sep 17 00:00:00 2001
  From: Ben Skeggs <bskeggs@redhat.com>
  Date: Thu, 21 Aug 2014 08:22:03 +1000
  Subject: [PATCH] drm/nouveau/bios: support for opcodes 0x47/0x48

  Signed-off-by: Ben Skeggs <bskeggs@redhat.com>
```