### PR TITLE
nvbios: Add unknown mem types for Pascal and "skip"

### DIFF
--- a/nvbios/mem.c
+++ b/nvbios/mem.c
@@ -323,7 +323,7 @@ envy_bios_print_mem_type(struct envy_bios *bios, FILE *out, unsigned mask) {
 	fprintf(out, "MEM TYPE table at 0x%x, version %x, %u entries\n", mt->offset, mt->version, mt->entriesnum);
 	if(mt->version == 0x10) {
 		printf("Detected ram type: %s\n",
-		       mem_type(mt->version, mt->offset + mt->hlen + (ram_cfg*mt->rlen)));
+		       strap ? mem_type(mt->version, mt->offset + mt->hlen + (ram_cfg*mt->rlen)) : "Missing strap_peek!");
 	}
 
 	envy_bios_dump_hex(bios, out, mt->offset, mt->hlen, mask);

--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -926,6 +926,12 @@ const char * mem_type(uint8_t version, uint16_t start)
 	case 3:
 		return "GDDR5";
 		break;
+	case 8:
+		return "GDDR5X";
+		break;
+	case 15:
+		return "Skip";
+		break;
 	default:
 		return "Unknown ram type";
 	}


### PR DESCRIPTION
Benefits from:
```
  From 4766ec53945f14f134fc51de782b362a51351cb1 Mon Sep 17 00:00:00 2001
  From: Ben Skeggs <bskeggs@redhat.com>
  Date: Tue, 4 Nov 2014 12:06:25 +1000
  Subject: [PATCH] drm/nouveau/bios: add parsing of BIT M(v2) +0x03 table

  We only support one kind of matching here (ramcfg strap), but it appears
  alternate methods are possible.  I wrote a tool to scan our vbios repo
  for other types, but did not see any used.  Hopefully this means there
  aren't any in the wild that will now break.

  Signed-off-by: Ben Skeggs <bskeggs@redhat.com>
```