### PR TITLE
nvbios/info: Correctly label GM117 (nv117) -> GM107 (nv117)

### DIFF
--- a/nvbios/info.c
+++ b/nvbios/info.c
@@ -258,10 +258,10 @@ int envy_bios_parse_bit_i (struct envy_bios *bios, struct envy_bios_bit_entry *b
 			bios->chipset = 0x108;
 			bios->chipset_name = "GK208/GK208B";
 			break;
-		/* GM117 */
+		/* GM107 */
 		case 0x8207:
 			bios->chipset = 0x117;
-			bios->chipset_name = "GM117";
+			bios->chipset_name = "GM107";
 			break;
 		/* GM200 */
 		case 0x8400:


### PR DESCRIPTION
Mislabeling seen in the wild with VBIOS from two GM107s.

Fixes:
```
  From 7aef7f84bf9cae61edda12f4dff5ce47724c7fce Mon Sep 17 00:00:00 2001
  From: Martin Peres <martin.peres@labri.fr>
  Date: Mon, 21 Jul 2014 17:01:46 +0200
  Subject: [PATCH] nvbios/info: detect the nve6/nv117
```