### PR TITLE
Two nvbios/info cleanups

### DIFF
--- a/nvbios/info.c
+++ b/nvbios/info.c
@@ -263,6 +263,11 @@ int envy_bios_parse_bit_i (struct envy_bios *bios, struct envy_bios_bit_entry *b
 			bios->chipset = 0x117;
 			bios->chipset_name = "GM117";
 			break;
+		/* GM108 */
+		case 0x8208:
+			bios->chipset = 0x118;
+			bios->chipset_name = "GM108";
+			break;
 		/* GM200 */
 		case 0x8400:
 			bios->chipset = 0x120;

--- a/nvbios/info.c
+++ b/nvbios/info.c
@@ -273,7 +273,7 @@ int envy_bios_parse_bit_i (struct envy_bios *bios, struct envy_bios_bit_entry *b
 			bios->chipset = 0x124;
 			bios->chipset_name = "GM204";
 			break;
-		/* GM200 */
+		/* GM206 */
 		case 0x8406:
 			bios->chipset = 0x126;
 			bios->chipset_name = "GM206";


### PR DESCRIPTION
Two small cleanups for `nvbios/info`:
* Correct code comment about GM206 (nv126)
* Add support for GM108 (nv118)