### PR TITLE
Fix python env invocation for better portability

### DIFF
--- a/cupti_trace/cupti_make_report.py
+++ b/cupti_trace/cupti_make_report.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (C) 2015 Samuel Pitoiset <samuel.pitoiset@gmail.com>
 # All Rights Reserved.

--- a/rnn/renouveau2rnn
+++ b/rnn/renouveau2rnn
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import sys
 import os
 import subprocess

--- a/rnn/rules2rnn
+++ b/rnn/rules2rnn
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import subprocess
 import sys
 import os

--- a/rnn/text2xml
+++ b/rnn/text2xml
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import sys
 from lxml import etree as ET
 

--- a/rnn/xml2text
+++ b/rnn/xml2text
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import sys
 from lxml import etree as ET
 


### PR DESCRIPTION
Enhance portability by using $PATH to locate `python3` and `python` executables, rather than hardcoded locations.