### PR TITLE
gf100: Add POST_DEPTH_COVERAGE register to database

### DIFF
--- a/rnndb/graph/gf100_3d.xml
+++ b/rnndb/graph/gf100_3d.xml
@@ -414,6 +414,7 @@ xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
 		<reg32 offset="0x0f00" name="UNK0F00" length="4">
 			<doc>Vertex subm?</doc>
 		</reg32>
+		<reg32 offset="0x0f1c" name="POST_DEPTH_COVERAGE" type="boolean" variants="GM204_3D-"/>
 		<reg32 offset="0x0f20" name="UNK0F20" length="5" type="boolean" variants="GK104_3D-"/>
 		<reg32 offset="0x0f54" name="STENCIL_BACK_FUNC_REF"/>
 		<reg32 offset="0x0f58" name="STENCIL_BACK_MASK"/>


### PR DESCRIPTION
Found with the trace from https://trello.com/c/kuMPh88f , verified
working in WIP for ARB_post_depth_coverage implementation:

https://github.com/Lyude/mesa/tree/wip/gm200-ARB_post_depth_coverage

Signed-off-by: Lyude <lyude@redhat.com>