### PR TITLE
rnndb/graph/slcg: Document missing SLCG (Second Level Clock Gating) registers

### DIFF
--- a/rnndb/graph/gf100_pgraph/gpc.xml
+++ b/rnndb/graph/gf100_pgraph/gpc.xml
@@ -145,6 +145,7 @@
 	<array offset="0x880" name="FFB" stride="0x080" length="1">
 		<reg32 offset="0x04" name="PM_MUX_A"/> <!-- or is it? -->
 		<reg32 offset="0x18" name="BLCG"/>
+		<reg32 offset="0x1c" name="SLCG" variants="GK104-"/>
 		<reg32 offset="0x20" name="ELPG0"/>
 		<reg32 offset="0x2c" name="PART_CONFIG">
 			<bitfield low="0" high="3" name="PART_COUNT"/>

--- a/rnndb/graph/gf100_pgraph/tpc.xml
+++ b/rnndb/graph/gf100_pgraph/tpc.xml
@@ -349,6 +349,7 @@
 		</reg32>
 		<reg32 offset="0x20" name="CTX_UNK20" variants="GF100:GK104"/>
 		<reg32 offset="0x24" name="CTX_UNK24" variants="GF100:GK104"/>
+		<reg32 offset="0x24" name="SLCG" variants="GK104-"/>
 		<reg32 offset="0x2c" name="PM_MUX">
 			<bitfield low="0" high="3" name="SEL"/>
 			<bitfield pos="31" name="ENABLE"/>


### PR DESCRIPTION
On Pascal now reports completely for gr SLCG:
```
PGRAPH.DISPATCH.HW_BLK.SLCG <= 0
PGRAPH.CTXCTL.UNK17C <= 0x20008
PGRAPH.CTXCTL.HW_BLK.SLCG <= 0x40
PGRAPH.TPBUS.HW_BLK.SLCG <= 0
PGRAPH.UNK6000.HW_BLK0.SLCG <= 0
PGRAPH.UNK5800.HW_BLK.SLCG <= 0
PGRAPH.UNK5900.HW_CGBLK.SLCG <= 0xfffffff0
PGRAPH.CCACHE.HW_BLK.SLCG <= 0
PGRAPH.SKED.HW_BLK.SLCG <= 0
PGRAPH.GPC_BROADCAST.CTXCTL.UNK17C <= 0x20008
PGRAPH.GPC_BROADCAST.CTXCTL.HW_BLK.SLCG <= 0x40
PGRAPH.GPC_BROADCAST.UNK500.HW_CGBLK.SLCG <= 0
PGRAPH.GPC_BROADCAST.UNK600.HW_BLK.SLCG <= 0
PGRAPH.GPC_BROADCAST.UNK680.HW_BLK.SLCG <= 0
PGRAPH.GPC_BROADCAST.UNK700.HW_BLK.SLCG <= 0
PGRAPH.GPC_BROADCAST.UNK380.SLCG <= 0
PGRAPH.GPC_BROADCAST.ESETUP.HW_CGBLK.SLCG <= 0
PGRAPH.GPC_BROADCAST.TPBUS.HW_BLK.SLCG <= 0
PGRAPH.GPC_BROADCAST.ZCULL.HW_BLK.SLCG <= 0
PGRAPH.GPC_BROADCAST.TPCONF.HW_BLK.SLCG <= 0xffffff80
PGRAPH.GPC_BROADCAST.UNKC80.HW_BLK.SLCG <= 0xfffffff8
PGRAPH.GPC_BROADCAST.UNKD00.HW_BLK.SLCG <= 0xffffffe0
PGRAPH.GPC_BROADCAST.UNKF00.HW_BLK.SLCG <= 0xffffffe0
PGRAPH.GPC_BROADCAST.UNKE00.HW_BLK.SLCG <= 0xfffffffe
PGRAPH.GPC_BROADCAST.CCACHE.HW_CGBLK0.SLCG <= 0x1fe
PGRAPH.GPC_BROADCAST.FFB.SLCG <= 0
PGRAPH.GPC_BROADCAST.TPC_ALL.MASTER.SLCG <= 0
PGRAPH.GPC_BROADCAST.TPC_ALL.TEX.HW_CGBLK0.SLCG <= 0
PGRAPH.GPC_BROADCAST.TPC_ALL.TEX.HW_CGBLK1.SLCG <= 0
PGRAPH.GPC_BROADCAST.TPC_ALL.TEX.HW_CGBLK2.SLCG <= 0
PGRAPH.GPC_BROADCAST.TPC_ALL.TEX.HW_CGBLK3.SLCG <= 0
PGRAPH.GPC_BROADCAST.TPC_ALL.TEX.HW_CGBLK4.SLCG <= 0
PGRAPH.GPC_BROADCAST.TPC_ALL.TEX.HW_CGBLK5.SLCG <= 0
PGRAPH.GPC_BROADCAST.TPC_ALL.TEX.HW_CGBLK6.SLCG <= 0
PGRAPH.GPC_BROADCAST.TPC_ALL.TEX.HW_CGBLK7.SLCG <= 0
PGRAPH.GPC_BROADCAST.TPC_ALL.TEX.HW_CGBLK8.SLCG <= 0
PGRAPH.GPC_BROADCAST.TPC_ALL.POLY.HW_BLK.SLCG <= 0x104
PGRAPH.GPC_BROADCAST.TPC_ALL.L1.HW_CGBLK1.SLCG <= 0
PGRAPH.GPC_BROADCAST.TPC_ALL.L1.HW_CGBLK2.SLCG <= 0
PGRAPH.GPC_BROADCAST.TPC_ALL.UNK400.HW_BLK.SLCG <= 0x1e
PGRAPH.GPC_BROADCAST.TPC_ALL.MP.HW_CGBLK1.SLCG <= 0
PGRAPH.GPC_BROADCAST.TPC_ALL.MP.HW_CGBLK2.SLCG <= 0xffedff00
PGRAPH.GPC_BROADCAST.TPC_ALL.MP.HW_CGBLK3.SLCG <= 0x1b00
PGRAPH.GPC_BROADCAST.TPC_ALL.MP.HW_CGBLK5.SLCG <= 0
PGRAPH.GPC_BROADCAST.TPC_ALL.MP.HW_CGBLK6.SLCG <= 0
PGRAPH.GPC_BROADCAST.PPC_ALL.HW_BLK0.SLCG <= 0x4115fc0
PGRAPH.GPC_BROADCAST.PPC_ALL.HW_BLK1.SLCG <= 0xfffffff0
PGRAPH.GPC_BROADCAST.PPC_ALL.HW_CGBLK0.SLCG <= 0xfffffff8
PGRAPH.ROP_BROADCAST.ZROP.HW_CGBLK0.SLCG <= 0
PGRAPH.ROP_BROADCAST.HW_CGBLK0.SLCG <= 0
PGRAPH.ROP_BROADCAST.CROP.HW_CGBLK0.SLCG <= 0
PGRAPH.ROP_BROADCAST.SLCG0 <= 0
```