### PR TITLE
rnndb/pci: Document Pascal PCI MSI rearm register (CYA_2)

### DIFF
--- a/rnndb/bus/pci.xml
+++ b/rnndb/bus/pci.xml
@@ -459,6 +459,7 @@
 		<bitfield pos="0" name="TRIGGER"/>
 		<bitfield low="1" high="11" name="TIME"/>
 	</reg32>
+	<reg32 offset="0x704" name="CYA_2" variants="GF100-"/><!-- write dummy value 0 to rearm PCI MSI on Pascal -->
 </group>
 
 <group name="nv_pci_hda">


### PR DESCRIPTION
nvgpu documents that writing a dummy value 0 to this register rearms PCI MSI on Pascal.