### PR TITLE
rnndb: Add more missing registers for GK110+

### DIFF
--- a/rnndb/memory/gf100_pbfb.xml
+++ b/rnndb/memory/gf100_pbfb.xml
@@ -51,6 +51,9 @@
 		<bitfield pos="31" name="AUTO_REFRESH"/>
 	</reg32>
 
+	<!-- Just a guess based off of near-by register writes -->
+	<reg32 offset="0x280" name="SLCG" variants="GK110-"/>
+
 	<reg32 offset="0x290" name="MEM_TIMINGS_0" variants="NV10:GF100">
 		<doc> This, and the next 6 regs, are all related to memtimings.
 			A good place to read might be http://www.tweakers.fr/timings.html .

--- a/rnndb/memory/gf100_pmfb.xml
+++ b/rnndb/memory/gf100_pmfb.xml
@@ -101,6 +101,7 @@
 	<stripe offset="0x280" name="HW_PGBLK">
 		<use-group name="gf100_hw_pgblk"/>
 	</stripe>
+	<reg32 offset="0x298" name="SLCG" variants="GK110-"/>
 </group>
 
 <group name="gf100_pmfb">
@@ -116,6 +117,9 @@
 	<stripe offset="0x40" name="HW_BLK1">
 		<use-group name="gf100_hw_blk"/>
 	</stripe>
+
+	<reg32 offset="0x50" name="SLCG" variants="GK110-"/>
+
 	<array name="SUBP_BROADCAST" offset="0x0800" stride="0x400" length="1">
 		<use-group name="gf100_pmfb_subp"/>
 	</array>

--- a/rnndb/memory/gf100_pxbar.xml
+++ b/rnndb/memory/gf100_pxbar.xml
@@ -18,9 +18,11 @@
 	</array>
 
 	<array name="UNK1800" offset="0x1800" stride="0x80" length="1">
-		<reg32 offset="0x20" name="BLCG" />
 		<stripe offset="0x10" name="HW_PGBLK" variants="GK104-">
 			<use-group name="gf100_hw_pgblk"/>
+		</stripe>
+		<stripe offset="0x20" name="HW_CGBLK">
+			<use-group name="gf100_hw_cgblk"/>
 		</stripe>
 	</array>
 
@@ -29,7 +31,7 @@
 	</stripe>
 
 	<array name="GPC_UNK2" offset="0x1c00" stride="0x20" length="32">
-		<stripe offset="0x00" name="HW_BLK" variants="GF100:GK104">
+		<stripe offset="0x00" name="HW_BLK" variants="GF100-">
 			<use-group name="gf100_hw_blk"/>
 		</stripe>
 	</array>


### PR DESCRIPTION
These are all of the slcg registers I've found thus-far that weren't
already documented in rnndb that I've come across in the vbios repo. As
well, the sources I used to verify each as much as possible:

Confirmed in android tegra repos:
 - 0x17e050
 - 0x17ea98
 - 0x13cc04 (this also made it obvious that 0x13cc00 exists beyond the
   GK104)

Confirmed in nvidia nvgpu repos:
 - 0x13c824

Guesses based off nearby register writes:
 - 0x10f280

The value of all of these registers is consistently 0x0, however that
seems to match up perfectly with the production values specified in
android's tegra drivers and nvgpu, with the disable value being
non-zero (0x0 must be some sort of enable I suppose).