### PR TITLE
cgen: Add .gitignore

### DIFF
--- a/cgen/.gitignore
+++ b/cgen/.gitignore
@@ -1,0 +1,4 @@
+bus.c
+fb.c
+gpu.c
+libcgen.a


### PR DESCRIPTION
Used to ignore locally-generated output files in cgen.

Fixes: 9e6b83e5 ("Single Source of Truth.")