### PR TITLE
cmake: Explicit on minimum version required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(ENVYTOOLS C CXX)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 enable_testing()
 
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=gnu11")

--- a/cgen/CMakeLists.txt
+++ b/cgen/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(ENVYTOOLS C)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 set(CGEN_INCLUDE_DIR ${CMAKE_BINARY_DIR}/include-generated)
 

--- a/cupti_trace/CMakeLists.txt
+++ b/cupti_trace/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(ENVYTOOLS C)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 find_package(CUDA)
 find_program(VALGRIND_EXECUTABLE valgrind)

--- a/demmt/CMakeLists.txt
+++ b/demmt/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(ENVYTOOLS C)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 add_executable(mmt_bin2dedma mmt_bin2dedma.c mmt_bin2dedma_nvidia.c mmt_bin_decode.c mmt_bin_decode_nvidia.c)
 add_executable(demmt

--- a/easm/CMakeLists.txt
+++ b/easm/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(ENVYTOOLS C)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 find_package(FLEX REQUIRED)
 find_package(BISON REQUIRED)

--- a/envydis/CMakeLists.txt
+++ b/envydis/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(ENVYTOOLS C)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-missing-braces")
 

--- a/envydis/test/CMakeLists.txt
+++ b/envydis/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 project(ENVYTOOLS C)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 add_test(fuc_smoke ${CMAKE_CURRENT_SOURCE_DIR}/fuc_smoke ${CMAKE_CURRENT_BINARY_DIR}/../envydis)

--- a/hwtest/CMakeLists.txt
+++ b/hwtest/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(ENVYTOOLS C CXX)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 option(DISABLE_HWTEST "Disable building hwtest" OFF)
 if (NOT DISABLE_HWTEST)

--- a/nva/CMakeLists.txt
+++ b/nva/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(ENVYTOOLS C)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 option(DISABLE_NVA "Disable building nva tools" OFF)
 if (NOT DISABLE_NVA)

--- a/nvbios/CMakeLists.txt
+++ b/nvbios/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(ENVYTOOLS C)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 add_library(envybios
 	bios.c print.c

--- a/nvhw/CMakeLists.txt
+++ b/nvhw/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(ENVYTOOLS C)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 add_library(nvhw chipset.c tile.c comp.c mpeg_crypt.c
 	pgraph_class.c pgraph_grobj.c

--- a/rnn/CMakeLists.txt
+++ b/rnn/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(ENVYTOOLS C)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 # <3 libxml2
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-pointer-sign")

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(ENVYTOOLS C)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 add_library(envyutil
 	path.c mask.c hash.c symtab.c colors.c yy.c astr.c aprintf.c

--- a/vdpow/CMakeLists.txt
+++ b/vdpow/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(ENVYTOOLS C)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 option(DISABLE_VDPOW "Disable building vdpow" OFF)
 if (NOT DISABLE_VDPOW)

--- a/vstream/CMakeLists.txt
+++ b/vstream/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(ENVYTOOLS C)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-missing-braces")
 

--- a/vstream/test/CMakeLists.txt
+++ b/vstream/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(ENVYTOOLS C)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 add_executable(vstest vstest.c)
 add_executable(predtest predtest.c)


### PR DESCRIPTION
envytools since 7e2e2e9a has required `cmake` 3.5 at a minimum. Let's be explicit about this minimum supported version via cmake's own dependency checking functionality.

Whilst changes in easm -- specifically to `FindFLEX` module `FLEX_TARGET` -- bumped the cmake requirement to 3.5, given easm is not optional let's just bump the cmake requirement across the tree. Most major distributions currently ship cmake 3.9+.

Fixes: 7e2e2e9a ("easm: Fix compilation in directories with space in name.")