### PR TITLE
Improve nvapy support in Travis-CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get -y install \
     libx11-dev \
     libxext-dev \
     # Optional dependency needed by nvapy
-    python3 \
+    python3-dev \
     cython3 \
     # Optional dependencies needed by vdpow \
     libpciaccess-dev \

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Optional dependencies needed by nva:
 - ``libx11``
 - ``libxext``
 - ``python3``
-- ``cython``
+- ``cython3``
 
 Optional dependencies needed by vdpow:
 
@@ -75,7 +75,7 @@ corresponding to the dependencies above.
 
 On ubuntu it can be done like this::
 
-    apt-get install cmake flex libpciaccess-dev bison libx11-dev libxext-dev libxml2-dev libvdpau-dev python3-dev
+    apt-get install cmake flex libpciaccess-dev bison libx11-dev libxext-dev libxml2-dev libvdpau-dev python3-dev cython3
 
 To build using ninja (recommended if you work on envytools)::
 

--- a/nva/CMakeLists.txt
+++ b/nva/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DISABLE_NVA)
 	pkg_check_modules(PC_XEXT xext)
 	pkg_search_module(PC_PYTHON python3 python-3.5)
 	find_package (Threads)
-	find_program (CYTHON_EXECUTABLE cython)
+	find_program (CYTHON_EXECUTABLE cython3)
 
 	if (PC_PCIACCESS_FOUND)
 
@@ -90,7 +90,7 @@ if (NOT DISABLE_NVA)
 				install(TARGETS nvapy DESTINATION ${NVAPY_PATH})
 			endif (NVAPY_PATH)
 		else(PC_PYTHON_FOUND AND CYTHON_EXECUTABLE)
-			message("Warning: nvapy won't be built because of un-met dependencies (python3 and/or cython)")
+			message("Warning: nvapy won't be built because of un-met dependencies (python3 and/or cython3)")
 		endif(PC_PYTHON_FOUND AND CYTHON_EXECUTABLE)
 
 		target_link_libraries(nvawatch ${CMAKE_THREAD_LIBS_INIT})

--- a/nva/CMakeLists.txt
+++ b/nva/CMakeLists.txt
@@ -90,7 +90,7 @@ if (NOT DISABLE_NVA)
 				install(TARGETS nvapy DESTINATION ${NVAPY_PATH})
 			endif (NVAPY_PATH)
 		else(PC_PYTHON_FOUND AND CYTHON_EXECUTABLE)
-			message("Warning: nvapy won't be built because of un-met dependencies (python3 and cython)")
+			message("Warning: nvapy won't be built because of un-met dependencies (python3 and/or cython)")
 		endif(PC_PYTHON_FOUND AND CYTHON_EXECUTABLE)
 
 		target_link_libraries(nvawatch ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
Includes:
* Add `nva/nvapy` to code that is built automatically as part of Travis-CI and PR integration testing.
* Improve the documentation of what the exact dependencies are (I've seen the confusing error message trip up potential developers before)