### PR TITLE
nvbios: DisplayPort / BIT('d') improvements

### DIFF
--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -1611,11 +1611,11 @@ struct envy_bios_T {
 	struct envy_bios_T_unk0 unk0;
 };
 
-struct envy_bios_d_unk0_entry {
+struct envy_bios_d_dp_info_entry {
 	uint16_t offset;
 };
 
-struct envy_bios_d_unk0 {
+struct envy_bios_d_dp_info {
 	uint16_t offset;
 	uint8_t valid;
 	uint8_t version;
@@ -1623,13 +1623,13 @@ struct envy_bios_d_unk0 {
 	uint8_t entriesnum;
 	uint8_t rlen;
 
-	struct envy_bios_d_unk0_entry *entries;
+	struct envy_bios_d_dp_info_entry *entries;
 };
 
 struct envy_bios_d {
 	struct envy_bios_bit_entry *bit;
 
-	struct envy_bios_d_unk0 unk0;
+	struct envy_bios_d_dp_info dp_info;
 };
 
 struct envy_bios_p_falcon_ucode_desc {
@@ -1926,7 +1926,7 @@ void envy_bios_print_T_unk0(struct envy_bios *, FILE *out, unsigned mask);
 
 int envy_bios_parse_bit_d(struct envy_bios *, struct envy_bios_bit_entry *);
 void envy_bios_print_bit_d(struct envy_bios *, FILE *out, unsigned mask);
-void envy_bios_print_d_unk0(struct envy_bios *, FILE *out, unsigned mask);
+void envy_bios_print_d_dp_info(struct envy_bios *, FILE *out, unsigned mask);
 
 int envy_bios_parse_dcb (struct envy_bios *bios);
 void envy_bios_print_dcb (struct envy_bios *bios, FILE *out, unsigned mask);

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -1615,6 +1615,21 @@ struct envy_bios_d_dp_info_entry {
 	uint16_t offset;
 };
 
+struct envy_bios_d_dp_info_level_entry {
+	uint16_t offset;
+	uint8_t valid;
+	uint8_t post_cursor_2;
+	uint8_t drive_current;
+	uint8_t pre_emphasis;
+	uint8_t tx_pu;
+};
+
+struct envy_bios_d_dp_info_level_entry_table {
+	uint16_t offset;
+
+	struct envy_bios_d_dp_info_level_entry *level_entries;
+};
+
 struct envy_bios_d_dp_info {
 	uint16_t offset;
 	uint8_t valid;
@@ -1622,8 +1637,16 @@ struct envy_bios_d_dp_info {
 	uint8_t hlen;
 	uint8_t entriesnum;
 	uint8_t rlen;
+	uint8_t target_size;
+	uint8_t levelentrytables_count;
+	uint8_t levelentry_size;
+	uint8_t levelentry_count;
+	uint8_t flags;
+	uint16_t regular_vswing;
+	uint16_t low_vswing;
 
 	struct envy_bios_d_dp_info_entry *entries;
+	struct envy_bios_d_dp_info_level_entry_table *level_entry_tables;
 };
 
 struct envy_bios_d {

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -1611,8 +1611,37 @@ struct envy_bios_T {
 	struct envy_bios_T_unk0 unk0;
 };
 
+enum envy_bios_d_dp_info_link_rate {
+	ENVY_BIOS_DP_INFO_LINK_RATE_162 = 0x06,
+	ENVY_BIOS_DP_INFO_LINK_RATE_270 = 0x0a,
+	ENVY_BIOS_DP_INFO_LINK_RATE_540 = 0x14,
+	ENVY_BIOS_DP_INFO_LINK_RATE_810 = 0x1e,
+};
+
+struct envy_bios_d_dp_info_before_link_speed {
+	uint16_t offset;
+	uint8_t valid;
+	uint8_t link_rate;
+	uint16_t link_rate_ptr;
+};
+
 struct envy_bios_d_dp_info_entry {
 	uint16_t offset;
+	uint8_t valid;
+	uint32_t key;
+	uint8_t flags;
+	uint16_t before_link_training;
+	uint16_t after_link_training;
+	uint16_t before_link_speed_0;
+	uint16_t enable_spread;
+	uint16_t disable_spread;
+	uint16_t disable_lt;
+	uint8_t level_entry_table_index;
+	uint8_t hbr2_min_vdt_index;
+
+	int before_link_speed_nums;
+
+	struct envy_bios_d_dp_info_before_link_speed *before_link_speed_entries;
 };
 
 struct envy_bios_d_dp_info_level_entry {

--- a/nvbios/d.c
+++ b/nvbios/d.c
@@ -101,7 +101,7 @@ static void
 envy_bios_parse_d_dp_info(struct envy_bios *bios)
 {
 	struct envy_bios_d_dp_info *dp_info = &bios->d.dp_info;
-	int err = 0, i;
+	int err = 0, i, j;
 
 	if (!dp_info->offset)
 		return;
@@ -109,9 +109,30 @@ envy_bios_parse_d_dp_info(struct envy_bios *bios)
 	bios_u8(bios, dp_info->offset, &dp_info->version);
 	switch (dp_info->version) {
 	case 0x40:
+	case 0x41:
 		err |= bios_u8(bios, dp_info->offset + 0x1, &dp_info->hlen);
 		err |= bios_u8(bios, dp_info->offset + 0x2, &dp_info->rlen);
 		err |= bios_u8(bios, dp_info->offset + 0x3, &dp_info->entriesnum);
+		err |= bios_u8(bios, dp_info->offset + 0x4, &dp_info->target_size);
+		err |= bios_u8(bios, dp_info->offset + 0x5, &dp_info->levelentrytables_count);
+		err |= bios_u8(bios, dp_info->offset + 0x6, &dp_info->levelentry_size);
+		err |= bios_u8(bios, dp_info->offset + 0x7, &dp_info->levelentry_count);
+		err |= bios_u8(bios, dp_info->offset + 0x8, &dp_info->flags);
+		dp_info->regular_vswing = 0;
+		dp_info->low_vswing     = 0;
+		dp_info->valid = !err;
+		break;
+	case 0x42:
+		err |= bios_u8(bios, dp_info->offset + 0x1, &dp_info->hlen);
+		err |= bios_u8(bios, dp_info->offset + 0x2, &dp_info->rlen);
+		err |= bios_u8(bios, dp_info->offset + 0x3, &dp_info->entriesnum);
+		err |= bios_u8(bios, dp_info->offset + 0x4, &dp_info->target_size);
+		err |= bios_u8(bios, dp_info->offset + 0x5, &dp_info->levelentrytables_count);
+		err |= bios_u8(bios, dp_info->offset + 0x6, &dp_info->levelentry_size);
+		err |= bios_u8(bios, dp_info->offset + 0x7, &dp_info->levelentry_count);
+		err |= bios_u8(bios, dp_info->offset + 0x8, &dp_info->flags);
+		err |= bios_u16(bios, dp_info->offset + 0x9, &dp_info->regular_vswing);
+		err |= bios_u16(bios, dp_info->offset + 0xb, &dp_info->low_vswing);
 		dp_info->valid = !err;
 		break;
 	default:
@@ -122,7 +143,43 @@ envy_bios_parse_d_dp_info(struct envy_bios *bios)
 	dp_info->entries = malloc(dp_info->entriesnum * sizeof(struct envy_bios_d_dp_info_entry));
 	for (i = 0; i < dp_info->entriesnum; ++i) {
 		struct envy_bios_d_dp_info_entry *e = &dp_info->entries[i];
-		e->offset = dp_info->offset + dp_info->hlen + i * dp_info->rlen;
+		e->offset = dp_info->offset + dp_info->hlen +
+		            i * dp_info->rlen;
+	}
+
+	dp_info->level_entry_tables = malloc(dp_info->levelentrytables_count * sizeof(struct envy_bios_d_dp_info_level_entry_table));
+	for (i = 0; i < dp_info->levelentrytables_count; ++i) {
+		struct envy_bios_d_dp_info_level_entry_table *let = &dp_info->level_entry_tables[i];
+		let->offset = dp_info->offset + dp_info->hlen +
+		              dp_info->entriesnum * dp_info->rlen +
+		              i * dp_info->levelentry_count * dp_info->levelentry_size;
+
+		let->level_entries = malloc(dp_info->levelentry_count * sizeof(struct envy_bios_d_dp_info_level_entry));
+		for (j = 0; j < dp_info->levelentry_count; ++j) {
+			struct envy_bios_d_dp_info_level_entry *le = &let->level_entries[j];
+			le->offset = let->offset + j * dp_info->levelentry_size;
+
+			switch (dp_info->version) {
+				case 0x40:
+				case 0x41:
+					err |= bios_u8(bios, le->offset + 0x0, &le->post_cursor_2);
+					err |= bios_u8(bios, le->offset + 0x1, &le->drive_current);
+					err |= bios_u8(bios, le->offset + 0x2, &le->pre_emphasis);
+					err |= bios_u8(bios, le->offset + 0x3, &le->tx_pu);
+					le->valid = !err;
+					break;
+				case 0x42:
+					le->post_cursor_2 = 0;
+					err |= bios_u8(bios, le->offset + 0x0, &le->drive_current);
+					err |= bios_u8(bios, le->offset + 0x1, &le->pre_emphasis);
+					err |= bios_u8(bios, le->offset + 0x2, &le->tx_pu);
+					le->valid = !err;
+					break;
+				default:
+					ENVY_BIOS_ERR("Unknown d DP INFO LEVEL ENTRY TABLE version 0x%x\n", dp_info->version);
+					return;
+				}
+		}
 	}
 }
 
@@ -130,7 +187,7 @@ void
 envy_bios_print_d_dp_info(struct envy_bios *bios, FILE *out, unsigned mask)
 {
 	struct envy_bios_d_dp_info *dp_info = &bios->d.dp_info;
-	int i;
+	int i, j;
 
 	if (!dp_info->offset || !(mask & ENVY_BIOS_PRINT_d))
 		return;
@@ -140,12 +197,35 @@ envy_bios_print_d_dp_info(struct envy_bios *bios, FILE *out, unsigned mask)
 	}
 
 	fprintf(out, "d DP INFO table at 0x%x, version %x\n", dp_info->offset, dp_info->version);
+	fprintf(out, " -- flags 0x%02x\n", dp_info->flags);
+	if (dp_info->version == 0x42)
+		fprintf(out, " -- regular_vswing 0x%04x, low_vswing 0x%04x\n", dp_info->regular_vswing, dp_info->low_vswing);
 	envy_bios_dump_hex(bios, out, dp_info->offset, dp_info->hlen, mask);
 	if (mask & ENVY_BIOS_PRINT_VERBOSE) fprintf(out, "\n");
 
+	fprintf(out, " -- DP INFO TABLE entries:\n");
 	for (i = 0; i < dp_info->entriesnum; ++i) {
 		struct envy_bios_d_dp_info_entry *e = &dp_info->entries[i];
 		envy_bios_dump_hex(bios, out, e->offset, dp_info->rlen, mask);
+		if (mask & ENVY_BIOS_PRINT_VERBOSE) fprintf(out, "\n");
+	}
+
+	fprintf(out, " -- DP INFO LEVEL TABLE entries:\n");
+	for (i = 0; i < dp_info->levelentrytables_count; ++i) {
+		struct envy_bios_d_dp_info_level_entry_table *let = &dp_info->level_entry_tables[i];
+
+		fprintf(out, "    [%i] DP INFO LEVEL TABLE:\n", i);
+		for (j = 0; j < dp_info->levelentry_count; ++j) {
+			struct envy_bios_d_dp_info_level_entry *le = &let->level_entries[j];
+			if (dp_info->version == 0x42)
+			  fprintf(out, "     %02i: DriveCurrent 0x%02x, PreEmphasis 0x%02x, TxPu 0x%02x\n", j,
+			    le->drive_current, le->pre_emphasis, le->tx_pu);
+			else
+			  fprintf(out, "     %02i: PostCursor2 0x%02x, DriveCurrent 0x%02x, PreEmphasis 0x%02x, TxPu 0x%02x\n", j,
+			    le->post_cursor_2, le->drive_current, le->pre_emphasis, le->tx_pu);
+			envy_bios_dump_hex(bios, out, le->offset, dp_info->levelentry_size, mask);
+		}
+
 		if (mask & ENVY_BIOS_PRINT_VERBOSE) fprintf(out, "\n");
 	}
 

--- a/nvbios/d.c
+++ b/nvbios/d.c
@@ -115,7 +115,7 @@ envy_bios_parse_d_unk0(struct envy_bios *bios)
 		unk0->valid = !err;
 		break;
 	default:
-		ENVY_BIOS_ERR("Unknown V UNK0 table version 0x%x\n", unk0->version);
+		ENVY_BIOS_ERR("Unknown d UNK0 table version 0x%x\n", unk0->version);
 		return;
 	}
 

--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -464,7 +464,7 @@ void envy_bios_print (struct envy_bios *bios, FILE *out, unsigned mask) {
 
 		envy_bios_print_T_unk0(bios, stdout, mask);
 
-		envy_bios_print_d_unk0(bios, stdout, mask);
+		envy_bios_print_d_dp_info(bios, stdout, mask);
 
 		envy_bios_print_p_falcon_ucode(bios, stdout, mask);
 		break;


### PR DESCRIPTION
Document in envytools our better understanding of BIT_TOKEN_DP_PTRS('d') within the vbios.

In particular, this decodes or locates:
* DisplayPort (DP) link training, speed change and spread scripts & configuration data;
* GPU registers used to enable support for various DP functionality;
* HBR3 functionality introduced with Pascal.

The new output can be produced with `./nvbios/nvbios -p d <path_to_vbios>`. Add `-v` to increase verbosity.

Thanks to Nvidia for releasing documentation!