### PR TITLE
nvbios: BIT('p')v2 / Falcon processor (PMU) ucode

### DIFF
--- a/nvbios/CMakeLists.txt
+++ b/nvbios/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(envybios
 	bit.c info.c dacload.c iunk.c
 	i2cscript.c
 	dcb.c dunk.c i2c.c gpio.c extdev.c conn.c mem.c mux.c power.c
-	D.c L.c T.c d.c
+	D.c L.c T.c d.c p.c
 )
 
 add_executable(nvbios nvbios.c)

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -1632,6 +1632,23 @@ struct envy_bios_d {
 	struct envy_bios_d_unk0 unk0;
 };
 
+struct envy_bios_p_falcon_ucode_desc {
+	uint32_t offset;
+	uint8_t valid;
+	uint32_t stored_size;
+	uint32_t uncompressed_size;
+	uint32_t virtual_entry;
+	uint32_t interface_offset;
+	uint32_t imem_phys_base;
+	uint32_t imem_load_size;
+	uint32_t imem_virt_base;
+	uint32_t imem_sec_base;
+	uint32_t imem_sec_size;
+	uint32_t dmem_offset;
+	uint32_t dmem_phys_base;
+	uint32_t dmem_load_size;
+};
+
 enum envy_bios_p_falcon_ucode_application_id {
 	ENVY_BIOS_FALCON_UCODE_APPLICATION_ID_PRE_OS  = 0x01,
 	ENVY_BIOS_FALCON_UCODE_APPLICATION_ID_DEVINIT = 0x04,
@@ -1646,6 +1663,8 @@ struct envy_bios_p_falcon_ucode_entry {
 	uint8_t application_id;
 	uint8_t target_id;
 	uint32_t desc_ptr;
+
+	struct envy_bios_p_falcon_ucode_desc desc;
 };
 
 struct envy_bios_p_falcon_ucode {

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -1632,6 +1632,12 @@ struct envy_bios_d {
 	struct envy_bios_d_unk0 unk0;
 };
 
+struct envy_bios_p {
+	struct envy_bios_bit_entry *bit;
+
+	/* struct envy_bios_p_unk0 unk0; */
+};
+
 struct envy_bios_block {
 	unsigned int start;
 	unsigned int len;
@@ -1711,6 +1717,7 @@ struct envy_bios {
 	struct envy_bios_L L;
 	struct envy_bios_T T;
 	struct envy_bios_d d;
+	struct envy_bios_p p;
 
 	struct envy_bios_block *blocks;
 	int blocksnum;
@@ -1844,6 +1851,9 @@ void envy_bios_print_power_unk8c(struct envy_bios *bios, FILE *out, unsigned mas
 void envy_bios_print_power_unk90(struct envy_bios *bios, FILE *out, unsigned mask);
 void envy_bios_print_power_unk94(struct envy_bios *bios, FILE *out, unsigned mask);
 void envy_bios_print_power_unk98(struct envy_bios *bios, FILE *out, unsigned mask);
+
+int envy_bios_parse_bit_p (struct envy_bios *bios, struct envy_bios_bit_entry *bit);
+void envy_bios_print_bit_p (struct envy_bios *bios, FILE *out, unsigned mask);
 
 int envy_bios_parse_bit_M (struct envy_bios *bios, struct envy_bios_bit_entry *bit);
 void envy_bios_print_bit_M (struct envy_bios *bios, FILE *out, unsigned mask);

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -1632,10 +1632,39 @@ struct envy_bios_d {
 	struct envy_bios_d_unk0 unk0;
 };
 
+enum envy_bios_p_falcon_ucode_application_id {
+	ENVY_BIOS_FALCON_UCODE_APPLICATION_ID_PRE_OS  = 0x01,
+	ENVY_BIOS_FALCON_UCODE_APPLICATION_ID_DEVINIT = 0x04,
+};
+
+enum envy_bios_p_falcon_ucode_target_id {
+	ENVY_BIOS_FALCON_UCODE_TARGET_ID_PMU = 0x01,
+};
+
+struct envy_bios_p_falcon_ucode_entry {
+	uint16_t offset;
+	uint8_t application_id;
+	uint8_t target_id;
+	uint32_t desc_ptr;
+};
+
+struct envy_bios_p_falcon_ucode {
+	uint16_t offset;
+	uint8_t valid;
+	uint8_t version;
+	uint8_t hlen;
+	uint8_t entriesnum;
+	uint8_t rlen;
+	uint8_t desc_version;
+	uint8_t desc_size;
+
+	struct envy_bios_p_falcon_ucode_entry *entries;
+};
+
 struct envy_bios_p {
 	struct envy_bios_bit_entry *bit;
 
-	/* struct envy_bios_p_unk0 unk0; */
+	struct envy_bios_p_falcon_ucode falcon_ucode;
 };
 
 struct envy_bios_block {
@@ -1855,6 +1884,7 @@ void envy_bios_print_power_unk98(struct envy_bios *bios, FILE *out, unsigned mas
 
 int envy_bios_parse_bit_p (struct envy_bios *bios, struct envy_bios_bit_entry *bit);
 void envy_bios_print_bit_p (struct envy_bios *bios, FILE *out, unsigned mask);
+void envy_bios_print_p_falcon_ucode(struct envy_bios *bios, FILE *out, unsigned mask);
 
 int envy_bios_parse_bit_M (struct envy_bios *bios, struct envy_bios_bit_entry *bit);
 void envy_bios_print_bit_M (struct envy_bios *bios, FILE *out, unsigned mask);

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -1792,6 +1792,7 @@ static inline int bios_string(struct envy_bios *bios, unsigned int offs, char *r
 #define ENVY_BIOS_PRINT_DCB_ALL		0x007f0000
 #define ENVY_BIOS_PRINT_T		0x00800000
 #define ENVY_BIOS_PRINT_d		0x01000000
+#define ENVY_BIOS_PRINT_p		0x02000000
 #define ENVY_BIOS_PRINT_ALL		0x1fffffff
 #define ENVY_BIOS_PRINT_BLOCKS		0x20000000
 #define ENVY_BIOS_PRINT_UNUSED		0x40000000

--- a/nvbios/bit.c
+++ b/nvbios/bit.c
@@ -54,8 +54,8 @@ static const struct {
 	{ 'N', 0, envy_bios_parse_bit_empty },	/* NOP */
 	{ 'P', 1, envy_bios_parse_bit_P },	/* Power v1 */
 	{ 'P', 2, envy_bios_parse_bit_P },	/* Power v2 */
-	{ 'p', 1, envy_bios_parse_bit_empty },	/* PMU */
-	{ 'p', 2, envy_bios_parse_bit_empty },  /* Falcon */
+	{ 'p', 1, envy_bios_parse_bit_p },	/* PMU */
+	{ 'p', 2, envy_bios_parse_bit_p },	/* Falcon */
 	{ 'R', 1, envy_bios_parse_bit_empty },	/* Bridge Firmware */
 	{ 'S', 1, envy_bios_parse_bit_empty },	/* String v1 */
 	{ 'S', 2, envy_bios_parse_bit_empty },	/* String v2 */

--- a/nvbios/bit.c
+++ b/nvbios/bit.c
@@ -55,6 +55,7 @@ static const struct {
 	{ 'P', 1, envy_bios_parse_bit_P },	/* Power v1 */
 	{ 'P', 2, envy_bios_parse_bit_P },	/* Power v2 */
 	{ 'p', 1, envy_bios_parse_bit_empty },	/* PMU */
+	{ 'p', 2, envy_bios_parse_bit_empty },  /* Falcon */
 	{ 'R', 1, envy_bios_parse_bit_empty },	/* Bridge Firmware */
 	{ 'S', 1, envy_bios_parse_bit_empty },	/* String v1 */
 	{ 'S', 2, envy_bios_parse_bit_empty },	/* String v2 */

--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -97,6 +97,7 @@ struct {
 	{ "L",		ENVY_BIOS_PRINT_L },
 	{ "T",		ENVY_BIOS_PRINT_T },
 	{ "d",		ENVY_BIOS_PRINT_d },
+	{ "p",		ENVY_BIOS_PRINT_p },
 	{ "i2cscript",	ENVY_BIOS_PRINT_I2CSCRIPT },
 	{ "dcball",	ENVY_BIOS_PRINT_DCB_ALL },
 	{ "dcb",	ENVY_BIOS_PRINT_DCB },

--- a/nvbios/p.c
+++ b/nvbios/p.c
@@ -92,5 +92,25 @@ envy_bios_parse_bit_p (struct envy_bios *bios, struct envy_bios_bit_entry *bit)
 void
 envy_bios_print_bit_p (struct envy_bios *bios, FILE *out, unsigned mask)
 {
+	struct envy_bios_p *p = &bios->p;
+	const char *name;
+	uint32_t addr;
+	int ret = 0, i = 0;
 
+	if (!p->bit || !(mask & ENVY_BIOS_PRINT_p))
+		return;
+
+	fprintf(out, "BIT table 'p' at 0x%x, version %i\n",
+		p->bit->offset, p->bit->version);
+
+	for (i = 0; i < p->bit->t_len; i+=4) {
+		ret = bios_u32(bios, p->bit->t_offset + i, &addr);
+		if (!ret && addr) {
+			name = "UNKNOWN";
+			ret = parse_at(bios, p, -1, i, &name);
+			fprintf(out, "0x%02x: 0x%x => %s TABLE\n", i, addr, name);
+		}
+	}
+
+	fprintf(out, "\n");
 }

--- a/nvbios/p.c
+++ b/nvbios/p.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2018 Rhys Kidd
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "bios.h"
+
+//
+
+struct p_known_tables {
+	uint8_t offset;
+	uint16_t *ptr;
+	const char *name;
+};
+
+static int
+parse_at(struct envy_bios *bios, struct envy_bios_p *p,
+	     int idx, int offset, const char ** name)
+{
+	return -EINVAL;
+}
+
+int
+envy_bios_parse_bit_p (struct envy_bios *bios, struct envy_bios_bit_entry *bit)
+{
+	return 0;
+}
+
+void
+envy_bios_print_bit_p (struct envy_bios *bios, FILE *out, unsigned mask)
+{
+
+}

--- a/nvbios/p.c
+++ b/nvbios/p.c
@@ -24,7 +24,7 @@
 
 #include "bios.h"
 
-//
+int envy_bios_parse_p_falcon_ucode(struct envy_bios *bios);
 
 struct p_known_tables {
 	uint8_t offset;
@@ -40,7 +40,7 @@ parse_at(struct envy_bios *bios, struct envy_bios_p *p,
 		/* { 0x00, &p->unk0.offset, "UNKNOWN" }, */
 	};
 	struct p_known_tables p2_tbls[] = {
-		/* { 0x00, &p->unk0.offset, "UNKNOWN" }, */
+		{ 0x00, &p->falcon_ucode.offset, "FALCON UCODE" },
 	};
 	struct p_known_tables *tbls;
 	int entries_count = 0;
@@ -94,6 +94,7 @@ envy_bios_parse_bit_p (struct envy_bios *bios, struct envy_bios_bit_entry *bit)
 		idx++;
 
 	/* parse tables */
+	envy_bios_parse_p_falcon_ucode(bios);
 
 	return 0;
 }
@@ -119,6 +120,87 @@ envy_bios_print_bit_p (struct envy_bios *bios, FILE *out, unsigned mask)
 			ret = parse_at(bios, p, -1, i, &name);
 			fprintf(out, "0x%02x: 0x%x => %s TABLE\n", i, addr, name);
 		}
+	}
+
+	fprintf(out, "\n");
+}
+
+static struct enum_val falcon_ucode_application_id_types[] = {
+	{ ENVY_BIOS_FALCON_UCODE_APPLICATION_ID_PRE_OS,	"PRE_OS" },
+	{ ENVY_BIOS_FALCON_UCODE_APPLICATION_ID_DEVINIT,"DEVINIT" },
+	{ 0 },
+};
+
+static struct enum_val falcon_ucode_target_id_types[] = {
+	{ ENVY_BIOS_FALCON_UCODE_TARGET_ID_PMU,	"PMU" },
+	{ 0 },
+};
+
+int
+envy_bios_parse_p_falcon_ucode(struct envy_bios *bios)
+{
+	struct envy_bios_p_falcon_ucode *falcon_ucode = &bios->p.falcon_ucode;
+	int i, err = 0;
+
+	if (!falcon_ucode->offset)
+		return -EINVAL;
+
+	bios_u8(bios, falcon_ucode->offset + 0x0, &falcon_ucode->version);
+	switch(falcon_ucode->version) {
+	case 0x1:
+		err |= bios_u8(bios, falcon_ucode->offset + 0x1, &falcon_ucode->hlen);
+		err |= bios_u8(bios, falcon_ucode->offset + 0x2, &falcon_ucode->rlen);
+		err |= bios_u8(bios, falcon_ucode->offset + 0x3, &falcon_ucode->entriesnum);
+
+		err |= bios_u8(bios, falcon_ucode->offset + 0x4, &falcon_ucode->desc_version);
+		err |= bios_u8(bios, falcon_ucode->offset + 0x5, &falcon_ucode->desc_size);
+		falcon_ucode->valid = !err;
+		break;
+	default:
+		ENVY_BIOS_ERR("Unknown FALCON UCODE table version 0x%x\n", falcon_ucode->version);
+		return -EINVAL;
+	};
+
+	err = 0;
+	falcon_ucode->entries = malloc(falcon_ucode->entriesnum * sizeof(struct envy_bios_p_falcon_ucode_entry));
+	for (i = 0; i < falcon_ucode->entriesnum; i++) {
+		uint32_t data = falcon_ucode->offset + falcon_ucode->hlen + i * falcon_ucode->rlen;
+
+		falcon_ucode->entries[i].offset = data;
+		err |= bios_u8(bios, data + 0x0, &falcon_ucode->entries[i].application_id);
+		err |= bios_u8(bios, data + 0x1, &falcon_ucode->entries[i].target_id);
+		err |= bios_u32(bios, data + 0x2, &falcon_ucode->entries[i].desc_ptr);
+	}
+
+	return 0;
+}
+
+void
+envy_bios_print_p_falcon_ucode(struct envy_bios *bios, FILE *out, unsigned mask)
+{
+	struct envy_bios_p_falcon_ucode *falcon_ucode = &bios->p.falcon_ucode;
+	int i;
+
+	if (!falcon_ucode->offset || !(mask & ENVY_BIOS_PRINT_p))
+		return;
+	if (!falcon_ucode->valid) {
+		ENVY_BIOS_ERR("Failed to parse FALCON UCODE table at 0x%x, version %x\n\n", falcon_ucode->offset, falcon_ucode->version);
+		return;
+	}
+
+	fprintf(out, "FALCON UCODE table at 0x%x, version %x\n", falcon_ucode->offset, falcon_ucode->version);
+	envy_bios_dump_hex(bios, out, falcon_ucode->offset, falcon_ucode->hlen, mask);
+	if (mask & ENVY_BIOS_PRINT_VERBOSE) fprintf(out, "\n");
+
+	for (i = 0; i < falcon_ucode->entriesnum; i++) {
+		struct envy_bios_p_falcon_ucode_entry *e = &falcon_ucode->entries[i];
+		const char *application_id = find_enum(falcon_ucode_application_id_types, e->application_id);
+		const char *target_id = find_enum(falcon_ucode_target_id_types, e->target_id);
+		fprintf(out, "UCODE %i: application_id 0x%02x [%s], target_id 0x%02x [%s], desc_ptr = 0x%x\n",
+				i, e->application_id, application_id, e->target_id, target_id, e->desc_ptr);
+
+		envy_bios_dump_hex(bios, out, e->offset, falcon_ucode->rlen, mask);
+		if (mask & ENVY_BIOS_PRINT_VERBOSE) fprintf(out, "\n");
 	}
 
 	fprintf(out, "\n");

--- a/nvbios/p.c
+++ b/nvbios/p.c
@@ -86,6 +86,15 @@ parse_at(struct envy_bios *bios, struct envy_bios_p *p,
 int
 envy_bios_parse_bit_p (struct envy_bios *bios, struct envy_bios_bit_entry *bit)
 {
+	struct envy_bios_p *p = &bios->p;
+	int idx = 0;
+
+	p->bit = bit;
+	while (!parse_at(bios, p, idx, -1, NULL))
+		idx++;
+
+	/* parse tables */
+
 	return 0;
 }
 

--- a/nvbios/power.c
+++ b/nvbios/power.c
@@ -72,14 +72,14 @@ struct P_known_tables {
 static int parse_at(struct envy_bios *bios, struct envy_bios_power *power,
 	     int idx, int offset, const char ** name)
 {
-	struct P_known_tables p1_tbls[] = {
+	struct P_known_tables P1_tbls[] = {
 		{ 0x00, &power->perf.offset, "PERFORMANCE" },
 		{ 0x04, &power->timing.offset, "MEMORY TIMINGS" },
 		{ 0x0c, &power->therm.offset, "THERMAL" },
 		{ 0x10, &power->volt.offset, "VOLTAGE" },
 		{ 0x15, &power->fan_calib.offset, "NVCLK PERFORMANCE" }
 	};
-	struct P_known_tables p2_tbls[] = {
+	struct P_known_tables P2_tbls[] = {
 		{ 0x00, &power->perf.offset, "PERFORMANCE" },
 		{ 0x04, &power->timing_map.offset, "MEMORY TIMINGS MAPPING" },
 		{ 0x08, &power->timing.offset, "MEMORY TIMINGS" },
@@ -126,11 +126,11 @@ static int parse_at(struct envy_bios *bios, struct envy_bios_power *power,
 	int ret;
 
 	if (power->bit->version == 0x1) {
-		tbls = p1_tbls;
-		entries_count = (sizeof(p1_tbls) / sizeof(struct P_known_tables));
+		tbls = P1_tbls;
+		entries_count = (sizeof(P1_tbls) / sizeof(struct P_known_tables));
 	} else if (power->bit->version == 0x2) {
-		tbls = p2_tbls;
-		entries_count = (sizeof(p2_tbls) / sizeof(struct P_known_tables));
+		tbls = P2_tbls;
+		entries_count = (sizeof(P2_tbls) / sizeof(struct P_known_tables));
 	} else
 		return -EINVAL;
 

--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -401,6 +401,7 @@ void envy_bios_print (struct envy_bios *bios, FILE *out, unsigned mask) {
 		envy_bios_print_bit_L(bios, stdout, mask);
 		envy_bios_print_bit_T(bios, stdout, mask);
 		envy_bios_print_bit_d(bios, stdout, mask);
+		envy_bios_print_bit_p(bios, stdout, mask);
 
 		envy_bios_print_dacload(bios, stdout, mask);
 		envy_bios_print_iunk21(bios, stdout, mask);

--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -465,6 +465,8 @@ void envy_bios_print (struct envy_bios *bios, FILE *out, unsigned mask) {
 		envy_bios_print_T_unk0(bios, stdout, mask);
 
 		envy_bios_print_d_unk0(bios, stdout, mask);
+
+		envy_bios_print_p_falcon_ucode(bios, stdout, mask);
 		break;
 	}
 	if (mask & ENVY_BIOS_PRINT_BLOCKS) {


### PR DESCRIPTION
Document within envytools a better understanding of BIT_TOKEN_FALCON_DATA('p') within the VBIOS.

This series adds:
* Support for the VBIOS BIT('p') version 2 table; and
* Ability to extract Falcon processor (PMU) ucode found in the VBIOS.

*Note*: The working understanding is that the PMU ucode(s) are bootloader, code and data loaded onto the PMU early during POSTing the card. For example, one of the "application_id"s handles limited, interim fan management. This isn't the full firmware ucode loaded subsequently by the blob.

The new output can be produced with `./nvbios/nvbios -p p <path_to_vbios>`. Add `-v` to increase verbosity and to extract the PMU ucode(s).