### PR TITLE
nvbios/T: Use 'TMDS Info Table' for first entry in BIT 'T' table

### DIFF
--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -1590,11 +1590,11 @@ struct envy_bios_L {
 	struct envy_bios_L_unk0 unk0;
 };
 
-struct envy_bios_T_unk0_entry {
+struct envy_bios_T_tmds_info_entry {
 	uint16_t offset;
 };
 
-struct envy_bios_T_unk0 {
+struct envy_bios_T_tmds_info {
 	uint16_t offset;
 	uint8_t valid;
 	uint8_t version;
@@ -1602,13 +1602,13 @@ struct envy_bios_T_unk0 {
 	uint8_t entriesnum;
 	uint8_t rlen;
 
-	struct envy_bios_T_unk0_entry *entries;
+	struct envy_bios_T_tmds_info_entry *entries;
 };
 
 struct envy_bios_T {
 	struct envy_bios_bit_entry *bit;
 
-	struct envy_bios_T_unk0 unk0;
+	struct envy_bios_T_tmds_info tmds_info;
 };
 
 enum envy_bios_d_dp_info_link_rate {
@@ -1974,7 +1974,7 @@ void envy_bios_print_L_unk0(struct envy_bios *, FILE *out, unsigned mask);
 
 int envy_bios_parse_bit_T(struct envy_bios *, struct envy_bios_bit_entry *);
 void envy_bios_print_bit_T(struct envy_bios *, FILE *out, unsigned mask);
-void envy_bios_print_T_unk0(struct envy_bios *, FILE *out, unsigned mask);
+void envy_bios_print_T_tmds_info(struct envy_bios *, FILE *out, unsigned mask);
 
 int envy_bios_parse_bit_d(struct envy_bios *, struct envy_bios_bit_entry *);
 void envy_bios_print_bit_d(struct envy_bios *, FILE *out, unsigned mask);

--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -462,7 +462,7 @@ void envy_bios_print (struct envy_bios *bios, FILE *out, unsigned mask) {
 
 		envy_bios_print_L_unk0(bios, stdout, mask);
 
-		envy_bios_print_T_unk0(bios, stdout, mask);
+		envy_bios_print_T_tmds_info(bios, stdout, mask);
 
 		envy_bios_print_d_dp_info(bios, stdout, mask);
 


### PR DESCRIPTION
Points to TMDS Info table that relates to Transition-minimized Differential Signaling (TMDS)
which is a technology for transmitting high-speed serial data, incorporating an advanced
coding algorithm which reduces electromagnetic interference over copper cables and enables
robust clock recovery at the receiver.

Utilized by DVI and HDMI video interfaces, amongst others.

Based on: https://download.nvidia.com/open-gpu-doc/BIOS-Information-Table/1/BIOS-Information-Table.html#_bit_tmds_ptrs