### PR TITLE
nvbios: Add HBM2 memory type, present on GV100 GPUs

### DIFF
--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -891,6 +891,9 @@ const char * mem_type(uint8_t version, uint16_t start)
 	case 3:
 		return "GDDR5";
 		break;
+	case 6:
+		return "HBM2";
+		break;
 	case 8:
 		return "GDDR5X";
 		break;


### PR DESCRIPTION
Tested on 3x GV100 VBIOSes, each of which are known to have HBM2 memory.

Unable to validate against a Tesla GP100, which is the only other known NVIDIA card with HBM2 at this time -- but confident this is correct.