### PR TITLE
nva/nvapy: Improve build dependency warning for python3 and/or cython

### DIFF
--- a/nva/CMakeLists.txt
+++ b/nva/CMakeLists.txt
@@ -90,7 +90,7 @@ if (NOT DISABLE_NVA)
 				install(TARGETS nvapy DESTINATION ${NVAPY_PATH})
 			endif (NVAPY_PATH)
 		else(PC_PYTHON_FOUND AND CYTHON_EXECUTABLE)
-			message("Warning: nvapy won't be built because of un-met dependencies (python3 and cython)")
+			message("Warning: nvapy won't be built because of un-met dependencies (python3 and/or cython)")
 		endif(PC_PYTHON_FOUND AND CYTHON_EXECUTABLE)
 
 		target_link_libraries(nvawatch ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
As discussed in #130 and #118:

Reflect that the absence of both, or either, dependency will mean `nvapy` won't be built due to un-met dependencies.