### PR TITLE
nva/nvapy: Improve nva documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Optional dependencies needed by nva:
 - ``libx11``
 - ``libxext``
 - ``python3``
-- ``cython``
+- ``cython3``
 
 Optional dependencies needed by vdpow:
 
@@ -75,7 +75,7 @@ corresponding to the dependencies above.
 
 On ubuntu it can be done like this::
 
-    apt-get install cmake flex libpciaccess-dev bison libx11-dev libxext-dev libxml2-dev libvdpau-dev python3-dev
+    apt-get install cmake flex libpciaccess-dev bison libx11-dev libxext-dev libxml2-dev libvdpau-dev python3-dev cython3
 
 To build using ninja (recommended if you work on envytools)::
 

--- a/nva/CMakeLists.txt
+++ b/nva/CMakeLists.txt
@@ -90,7 +90,7 @@ if (NOT DISABLE_NVA)
 				install(TARGETS nvapy DESTINATION ${NVAPY_PATH})
 			endif (NVAPY_PATH)
 		else(PC_PYTHON_FOUND AND CYTHON_EXECUTABLE)
-			message("Warning: nvapy won't be built because of un-met dependencies (python3 and/or cython)")
+			message("Warning: nvapy won't be built because of un-met dependencies (python3 and/or cython3)")
 		endif(PC_PYTHON_FOUND AND CYTHON_EXECUTABLE)
 
 		target_link_libraries(nvawatch ${CMAKE_THREAD_LIBS_INIT})

--- a/nva/CMakeLists.txt
+++ b/nva/CMakeLists.txt
@@ -90,7 +90,7 @@ if (NOT DISABLE_NVA)
 				install(TARGETS nvapy DESTINATION ${NVAPY_PATH})
 			endif (NVAPY_PATH)
 		else(PC_PYTHON_FOUND AND CYTHON_EXECUTABLE)
-			message("Warning: nvapy won't be built because of un-met dependencies (python3 and cython)")
+			message("Warning: nvapy won't be built because of un-met dependencies (python3 and/or cython)")
 		endif(PC_PYTHON_FOUND AND CYTHON_EXECUTABLE)
 
 		target_link_libraries(nvawatch ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
As discussed in #130 and #118:

`cython3` required as nva/nvapy requires `python3` as a minimum dependency.

Cmake gracefully falls back to `cython` for distributions that have not renamed the built executable that provides Python 3 support.



