### PR TITLE
Improve PDISPLAY FE_CLASSES

### DIFF
--- a/rnndb/display/g80_pdisplay.xml
+++ b/rnndb/display/g80_pdisplay.xml
@@ -119,6 +119,9 @@
 				<value value="0x917d" name="GK104_DISPLAY_MASTER"/>
 				<value value="0x927d" name="GK110_DISPLAY_MASTER"/>
 				<value value="0x947d" name="GM107_DISPLAY_MASTER"/>
+				<value value="0x957d" name="GM200_DISPLAY_MASTER"/> <!-- DISP025X Core Channel -->
+				<value value="0x977d" name="GP100_DISPLAY_MASTER"/> <!-- DISP027X Core Channel -->
+				<value value="0x987d" name="GP102_DISPLAY_MASTER"/> <!-- DISP028X Core Channel -->
 			</bitfield>
 		</reg32>
 

--- a/rnndb/display/g80_pdisplay.xml
+++ b/rnndb/display/g80_pdisplay.xml
@@ -109,7 +109,7 @@
 				<value value="0x0220" name="2_2"/> <!-- GK110 -->
 				<value value="0x0240" name="2_4"/> <!-- GM107 -->
 			</bitfield>
-			<bitfield low="16" high="31" name="CLASS">
+			<bitfield low="16" high="31" name="CLASS_ID">
 				<value value="0x507d" name="G80_DISPLAY_MASTER"/>
 				<value value="0x827d" name="G84_DISPLAY_MASTER"/>
 				<value value="0x837d" name="G200_DISPLAY_MASTER"/>


### PR DESCRIPTION
rnndb/disp/g80:
- Add recent display classes for GM200, GP100 and GP102
- Rename CLASS to CLASS_ID

Sources:
https://download.nvidia.com/open-gpu-doc/Display-Class-Methods/2/README.txt
https://download.nvidia.com/open-gpu-doc/Display-Ref-Manuals/1/gv100/dev_display.ref