### PR TITLE
rnndb/pdisp: Improve PDISPLAY SOR and DisplayPort TPG documentation

### DIFF
--- a/rnndb/display/g80_pdisplay.xml
+++ b/rnndb/display/g80_pdisplay.xml
@@ -844,6 +844,21 @@
 		</group>
 
 		<group name="g80_sor">
+			<enum name="g80_sor_dp_tpg_lane_pattern">
+				<value value="0x0" name="NOPATTERN"/>
+				<value value="0x1" name="TRAINING1"/>
+				<value value="0x2" name="TRAINING2"/>
+				<value value="0x3" name="TRAINING3"/>
+				<value value="0x4" name="D102"/>
+				<value value="0x5" name="SBLERRRATE"/>
+				<value value="0x6" name="PRBS7"/>
+				<value value="0x7" name="CSTM"/>
+				<value value="0x8" name="HBR2_COMPLIANCE"/>
+				<value value="0x9" name="CP2520_PAT1"/>
+				<value value="0xa" name="CP2520_PAT3"/>
+				<value value="0xb" name="TRAINING4"/>
+			</enum>
+
 			<reg32 offset="0x000" name="CAP" access="r" type="SOR_CAP"/>
 			<reg32 offset="0x004" name="PWR">
 				<bitfield pos="0" name="NORMAL_STATE">
@@ -901,6 +916,20 @@
 						<value value="1" name="1"/>
 						<value value="2" name="2"/>
 					</bitfield>
+				</reg32>
+				<reg32 offset="0x10" name="TPG">
+					<bitfield high="3" low="0" name="LANE0_PATTERN" type="g80_sor_dp_tpg_lane_pattern"/>
+					<bitfield pos="4" name="LANE0_SCRAMBLEREN"/>
+					<bitfield pos="6" name="LANE0_CHANNELCODING"/>
+					<bitfield high="11" low="8" name="LANE1_PATTERN" type="g80_sor_dp_tpg_lane_pattern"/>
+					<bitfield pos="12" name="LANE1_SCRAMBLEREN"/>
+					<bitfield pos="14" name="LANE1_CHANNELCODING"/>
+					<bitfield high="19" low="16" name="LANE2_PATTERN" type="g80_sor_dp_tpg_lane_pattern"/>
+					<bitfield pos="20" name="LANE2_SCRAMBLEREN"/>
+					<bitfield pos="22" name="LANE2_CHANNELCODING"/>
+					<bitfield high="27" low="24" name="LANE3_PATTERN" type="g80_sor_dp_tpg_lane_pattern"/>
+					<bitfield pos="28" name="LANE3_SCRAMBLEREN"/>
+					<bitfield pos="30" name="LANE3_CHANNELCODING"/>
 				</reg32>
 				<reg32 offset="0x18" name="LANE_DRIVE_CURRENT"/>
 				<reg32 offset="0x20" name="LANE_PREEMPHASIS"/>

--- a/rnndb/display/g80_pdisplay.xml
+++ b/rnndb/display/g80_pdisplay.xml
@@ -234,11 +234,14 @@
 		<reg32 offset="0x01D0" name="DAC_CAP" stride="0x4" length="3" type="DAC_CAP"/>
 
 		<bitset name="SOR_CAP" varset="chipset">
+			<bitfield pos="31" name="LVDS_ONLY"/>
+			<bitfield pos="27" name="DP_8_LANES"/>
 			<bitfield pos="26" name="DP_INTERLACE" variants="GF119-"/>
 			<bitfield pos="25" name="DP_B" variants="GT215-"/>
 			<bitfield pos="24" name="DP_A" variants="GT215-"/>
 			<bitfield pos="20" name="DDI" variants="G80:GT215"/>
-			<bitfield pos="16" name="UNK16"/>
+			<bitfield pos="16" name="SDI"/>
+			<bitfield pos="13" name="DISPLAY_OVER_PCIE"/>
 			<bitfield pos="12" name="SINGLE_TMDS_225_MHZ" variants="GT215:GF119"/>
 			<bitfield pos="11" name="DUAL_TMDS"/>
 			<bitfield pos="10" name="DUAL_SINGLE_TMDS" variants="G80:GT215"/>

--- a/rnndb/display/g80_pdisplay.xml
+++ b/rnndb/display/g80_pdisplay.xml
@@ -893,6 +893,7 @@
 			</reg32>
 			<array offset="0x100" name="LINK" stride="0x080" length="2">
 				<reg32 offset="0x0c" name="DP_CTRL">
+					<bitfield pos="0" name="ENABLE"/>
 					<bitfield pos="14" name="ENHANCED_FRAME_ENABLED"/>
 					<bitfield high="20" low="16" name="LANE_MASK"/> <!-- XXX: not 19? -->
 					<bitfield high="27" low="24" name="TRAINING_PATTERN">

--- a/rnndb/display/g80_pdisplay.xml
+++ b/rnndb/display/g80_pdisplay.xml
@@ -862,9 +862,18 @@
 					<value value="0" name="NORMAL"/>
 					<value value="1" name="ALT"/>
 				</bitfield>
-				<bitfield pos="24" name="HALT_DELAY"/>
-				<bitfield pos="28" name="MODE"/>
-				<bitfield pos="31" name="TRIGGER"/>
+				<bitfield pos="24" name="HALT_DELAY">
+					<value value="0" name="DONE"/>
+					<value value="1" name="ACTIVE"/>
+				</bitfield>
+				<bitfield pos="28" name="MODE">
+					<value value="0" name="NORMAL"/>
+					<value value="1" name="SAFE"/>
+				</bitfield>
+				<bitfield pos="31" name="SETTING_NEW">
+					<value value="0" name="DONE"/>
+					<value value="1" name="TRIGGER"/> <!-- on write, for read name is PENDING -->
+				</bitfield>
 			</reg32>
 			<reg32 offset="0x00c" name="PLL0"/>
 			<reg32 offset="0x010" name="PLL1"/>


### PR DESCRIPTION
Improvements to missing bitfield entries in:
* NV_PDISP_SOR_CAP(i)
* NV_PDISP_SOR_PWR(i)
* NV_PDISP_SOR_DP_LINKCTL(i,j)

Document DisplayPort Test Pattern Group (TPG):
* NV_PDISP_SOR_DP_TPG(i,j)

Source: https://download.nvidia.com/open-gpu-doc/Display-Ref-Manuals/1/gv100/dev_display.ref