### PR TITLE
hwdocs/maxwell: add initial CUDA ISA docs with iadd3 and xmad

### DIFF
--- a/docs/hw/graph/maxwell/cuda/index.rst
+++ b/docs/hw/graph/maxwell/cuda/index.rst
@@ -7,3 +7,4 @@ Contents:
    :titlesonly:
 
    isa
+   int

--- a/docs/hw/graph/maxwell/cuda/index.rst
+++ b/docs/hw/graph/maxwell/cuda/index.rst
@@ -1,0 +1,9 @@
+Maxwell CUDA processors
+=======================
+
+Contents:
+
+.. toctree::
+   :titlesonly:
+
+   isa

--- a/docs/hw/graph/maxwell/cuda/int.rst
+++ b/docs/hw/graph/maxwell/cuda/int.rst
@@ -32,7 +32,7 @@ cc
 
 Set the condition code.
 
-.. _maxwell-opg-iadd3
+.. _maxwell-opg-iadd3:
 
 Addition: iadd3
 ===============
@@ -53,7 +53,7 @@ Adds three integers. The flag ``mode`` may optionally be ``rs`` or ``ls``.
       default: DST = add_with_carry((SRC1 + SRC2), SRC3); break;
     }
 
-.. _maxwell-opg-xmad
+.. _maxwell-opg-xmad:
 
 Multiply-add: xmad
 ==================

--- a/docs/hw/graph/maxwell/cuda/int.rst
+++ b/docs/hw/graph/maxwell/cuda/int.rst
@@ -20,7 +20,7 @@ Negate the operand.
 h0/h1
 -----
 
-An optional flag that can be either H0 or H1. With H1, the high 16 bits of the operand are used. With H0, the low 16 bits.
+An optional flag that can be either ``h0`` or ``h1``. With ``h1``, the high 16 bits of the operand are used. With ``h0``, the low 16 bits are used.
 
 x
 -
@@ -43,12 +43,59 @@ Addition: iadd3
   iadd3 [x,cc] REG0 [neg] REG1 [neg] CB2 [neg] REG3
   iadd3 [x,cc] REG0 [neg] REG1 [neg] S20_2 [neg] REG3
 
-Adds three integers. The flag "mode" may optionally by RS or LS.
+Adds three integers. The flag ``mode`` may optionally be ``rs`` or ``ls``.
 
 ::
 
     switch (mode) {
-      case RS: DST = add_with_carry(((SRC1 + SRC2) >> 16), SRC3); break;
-      case LS: DST = add_with_carry(((SRC1 + SRC2) << 16), SRC3); break;
-      default: DST = add_with_carry(SRC1, SRC2, SRC3); break;
+      case rs: DST = add_with_carry(((SRC1 + SRC2) >> 16), SRC3); break;
+      case ls: DST = add_with_carry(((SRC1 + SRC2) << 16), SRC3); break;
+      default: DST = add_with_carry((SRC1 + SRC2), SRC3); break;
     }
+
+.. _maxwell-opg-xmad
+
+Multiply-add: xmad
+==================
+
+::
+
+  xmad [src1_type,src2_type,psl,mrg,cmode,x,cc] REG0 [h1] REG1 [h1] REG2 REG3
+  xmad [src1_type,src2_type,cmode,x,cc] REG0 [h1] REG1 [h1] REG2 CB3
+  xmad [src1_type,src2_type,psl,mrg,cmode,x,cc] REG0 [h1] REG1 [h1] CB2 REG3
+  xmad [src1_type,src2_type,psl,mrg,cmode,x,cc] REG0 [h1] REG1 [h1] S20_2 REG3
+
+Multiplies two 16-bit integers and adds a 32 bit integer, along with a bunch of
+other stuff.
+
+If one of ``src1_type`` or ``src2_type`` is set, the other must also be set. They can be ``s16 u16``, ``u16 s16`` or ``s16 s16``.
+
+The flag ``cmode`` may optionally be ``clo``, ``chi``, ``csfu`` or ``cbcc``. The ``cbcc``
+mode may not be specified for the constant buffer forms.
+
+::
+
+    uint32_t p_a = SRC1.h1 ? SRC1>>16 : SRC1&0xffff;
+    uint32_t p_b = SRC2.h1 ? SRC2>>16 : SRC2&0xffff;
+    if (src1_type == s16) p_a = sign_extend_from_16_to_32(p_a);
+    if (src2_type == s16) p_b = sign_extend_from_16_to_32(p_b);
+
+    uint32_t p = p_a * p_b;
+    if (psl) p <<= 16;
+
+    uint32_t c = SRC3;
+    switch (cmode) {
+      case clo: c = c & 0xffff; break;
+      case chi: c = c >> 16; break;
+      case cbcc: c += SRC2 << 16; break;
+      case csfu: {
+        if (p_a==0 || p_b==0) break;
+        //v & 0x80000000 -> as_twos_complement(v) < 0
+        if (p_a & 0x80000000) c -= 65536;
+        if (p_b & 0x80000000) c -= 65536;
+        break;
+      }
+    }
+
+    DST0 = add_with_carry(p, c);
+    if (mrg) DST0 = (DST0 & 0xffff) | (SRC2<<16);

--- a/docs/hw/graph/maxwell/cuda/int.rst
+++ b/docs/hw/graph/maxwell/cuda/int.rst
@@ -1,0 +1,54 @@
+.. _maxwell-int:
+
+===============================
+Integer Arithmetic Instructions
+===============================
+
+.. contents::
+
+Introduction
+============
+
+Common Flags
+============
+
+neg
+---
+
+Negate the operand.
+
+h0/h1
+-----
+
+An optional flag that can be either H0 or H1. With H1, the high 16 bits of the operand are used. With H0, the low 16 bits.
+
+x
+-
+
+Use the carry flag.
+
+cc
+--
+
+Set the carry flag.
+
+.. _maxwell-opg-iadd3
+
+Addition: iadd3
+===============
+
+::
+
+  iadd3 [mode,x,cc] REG0 [neg,h0/h1] REG1 [neg,h0/h1] REG2 [neg,h0/h1] REG3
+  iadd3 [x,cc] REG0 [neg] REG1 [neg] CB2 [neg] REG3
+  iadd3 [x,cc] REG0 [neg] REG1 [neg] S20_2 [neg] REG3
+
+Adds three integers. The flag "mode" may optionally by RS or LS.
+
+::
+
+    switch (mode) {
+      case RS: DST = add_with_carry(((SRC1 + SRC2) >> 16), SRC3); break;
+      case LS: DST = add_with_carry(((SRC1 + SRC2) << 16), SRC3); break;
+      default: DST = add_with_carry(SRC1, SRC2, SRC3); break;
+    }

--- a/docs/hw/graph/maxwell/cuda/int.rst
+++ b/docs/hw/graph/maxwell/cuda/int.rst
@@ -63,7 +63,7 @@ Multiply-add: xmad
   xmad [src1_type,src2_type,psl,mrg,cmode,x,cc] REG0 [h1] REG1 [h1] REG2 REG3
   xmad [src1_type,src2_type,cmode,x,cc] REG0 [h1] REG1 [h1] REG2 CB3
   xmad [src1_type,src2_type,psl,mrg,cmode,x,cc] REG0 [h1] REG1 [h1] CB2 REG3
-  xmad [src1_type,src2_type,psl,mrg,cmode,x,cc] REG0 [h1] REG1 [h1] S20_2 REG3
+  xmad [src1_type,src2_type,psl,mrg,cmode,x,cc] REG0 [h1] REG1 S20_2 REG3
 
 Multiplies two 16-bit integers and adds a 32 bit integer, along with a bunch of
 other stuff.

--- a/docs/hw/graph/maxwell/cuda/int.rst
+++ b/docs/hw/graph/maxwell/cuda/int.rst
@@ -25,12 +25,12 @@ An optional flag that can be either ``h0`` or ``h1``. With ``h1``, the high 16 b
 x
 -
 
-Use the carry flag.
+Use the condition code.
 
 cc
 --
 
-Set the carry flag.
+Set the condition code.
 
 .. _maxwell-opg-iadd3
 

--- a/docs/hw/graph/maxwell/cuda/isa.rst
+++ b/docs/hw/graph/maxwell/cuda/isa.rst
@@ -22,12 +22,13 @@ Some notes for reading this documentation:
 - CB<n> is a reference to the contents of a constant buffer.
 - U<b>_<n> is a b-bit unsigned immediate value.
 - S<b>_<n> is a b-bit signed immediate value.
-- The "carry flag" is not a instruction flag, but a register.
 - Some subtleties may lie in an instruction's description if putting it in the behaviour text would be too verbose.
 - add_with_carry(a, b) returns the sum of ``a`` and ``b`` using the carry flag, and writes the carry flag.
     - It does not use and/or set the carry flag if the appropriate instruction flags are not specified.
 - Instruction flags in between [ and ] are optional.
 - The order of the flags (even in between [ and ]) is what is expected by envyas.
+- The "carry flag" or "condition code" is not a instruction flag, but a register.
+- The terms "condition code" and "carry flag" are used interchangeably, depending on which is clearest.
 
 Instructions
 ============

--- a/docs/hw/graph/maxwell/cuda/isa.rst
+++ b/docs/hw/graph/maxwell/cuda/isa.rst
@@ -24,8 +24,8 @@ Some notes for reading this documentation:
 - S<b>_<n> is a b-bit signed immediate value.
 - The "carry flag" is not a instruction flag, but a register.
 - Some subtleties may lie in an instruction's description if putting it in the behaviour text would be too verbose.
-- add_with_carry(a, b, ...) returns the sum of the arguments using the carry flag, and writes the carry flag.
-    - It does not use and/or set the carry flag if the appropriate flags are not specified.
+- add_with_carry(a, b) returns the sum of ``a`` and ``b`` using the carry flag, and writes the carry flag.
+    - It does not use and/or set the carry flag if the appropriate instruction flags are not specified.
 - Instruction flags in between [ and ] are optional.
 - The order of the flags (even in between [ and ]) is what is expected by envyas.
 

--- a/docs/hw/graph/maxwell/cuda/isa.rst
+++ b/docs/hw/graph/maxwell/cuda/isa.rst
@@ -1,0 +1,37 @@
+.. _maxwell-isa:
+
+================
+Maxwell CUDA ISA
+================
+
+.. contents::
+
+
+Introduction
+============
+
+This currently is not a complete reference of known functionality, but where
+behaviour not obvious from envydis/gm107.c can be documented.
+
+Some notes for reading this documentation:
+
+- An instruction's docs is split into three sections, the forms text, the description and the behaviour text.
+- The first operand is usually the destination.
+- The behaviour text uses the notation SRC<n>/DST, while the forms text does not.
+- REG<n> is a reference to a register.
+- CB<n> is a reference to the contents of a constant buffer.
+- U<b>_<n> is a b-bit unsigned immediate value.
+- S<b>_<n> is a b-bit signed immediate value.
+- The "carry flag" is not a instruction flag, but a register.
+- Some subtleties may lie in an instruction's description if putting it in the behaviour text would be too verbose.
+- add_with_carry(a, b, ...) returns the sum of the arguments using the carry flag, and writes the carry flag.
+    - It does not use and/or set the carry flag if the appropriate flags are not specified.
+- Instruction flags in between [ and ] are optional.
+- The order of the flags (even in between [ and ]) is what is expected by envyas.
+
+Instructions
+============
+
+The instructions are roughly divided into the following groups:
+
+- :ref:`maxwell-int`

--- a/docs/hw/graph/maxwell/index.rst
+++ b/docs/hw/graph/maxwell/index.rst
@@ -8,3 +8,4 @@ Contents:
 
    3d
    compute
+   cuda


### PR DESCRIPTION
This isn't really something meant to be complete, but to document instructions with behaviour not obvious from reading envydis/gm107.c (such as iadd3, xmad and maybe texture instructions).

Currently, it just documents iadd3 and xmad.