### PR TITLE
 rnndb/memory/gf100_pbfb: Support Pascal framebuffer partition addressing changes

### DIFF
--- a/rnndb/memory/gf100_pbfb.xml
+++ b/rnndb/memory/gf100_pbfb.xml
@@ -139,6 +139,12 @@
 		<bitfield low="0" high="3" name="SRC"/>
 		<bitfield low="4" high="7" name="PRIV"/>
 	</reg32>
+
+	<reg32 offset="0x8e0" name="FBIO_CMD_DELAY" variants="GK104-">
+		<bitfield low="0" high="3" name="SRC"/>
+		<bitfield low="4" high="7" name="PRIV"/>
+	</reg32>
+
 </group>
 
 <!-- Pre-Pascal variants -->

--- a/rnndb/memory/gf100_pbfb.xml
+++ b/rnndb/memory/gf100_pbfb.xml
@@ -136,15 +136,27 @@
 	</array>
 </group>
 
-<array name="PBFB_BROADCAST" offset="0x10f000" stride="0x1000" length="1" variants="GF100-">
+<!-- Pre-Pascal variants -->
+<array name="PBFB_BROADCAST" offset="0x10f000" stride="0x1000" length="1" variants="GF100:GP100">
 	<use-group name="gf100_pbfb"/>
 </array>
 
-<array name="PBFB" offset="0x110000" stride="0x1000" length="16" variants="GF100-">
+<array name="PBFB" offset="0x110000" stride="0x1000" length="16" variants="GF100:GP100">
 	<use-group name="gf100_pbfb"/>
 </array>
 
-<array name="PBFB_MC" offset="0x11d000" stride="0x1000" length="3" variants="GF100-" />
+<array name="PBFB_MC" offset="0x11d000" stride="0x1000" length="3" variants="GF100:GP100" />
+
+<!-- Pascal onwards variants -->
+<array name="PBFB_BROADCAST" offset="0x9a0000" stride="0x4000" length="1" variants="GP100-">
+	<use-group name="gf100_pbfb"/>
+</array>
+
+<array name="PBFB" offset="0x900000" stride="0x4000" length="16" variants="GP100-">
+	<use-group name="gf100_pbfb"/>
+</array>
+
+<array name="PBFB_MC" offset="0x980000" stride="0x4000" length="3" variants="GP100-" />
 
 </domain>
 

--- a/rnndb/memory/gf100_pbfb.xml
+++ b/rnndb/memory/gf100_pbfb.xml
@@ -134,6 +134,11 @@
 	<array name="PFB_RAMCHIP_CFG" offset="0x300" stride="0x30" length="1" variants="GF100-">
 		<use-group name="ramchip_cfg" />
 	</array>
+
+	<reg32 offset="0x65c" name="FBIO_DELAY" variants="GK104-">
+		<bitfield low="0" high="3" name="SRC"/>
+		<bitfield low="4" high="7" name="PRIV"/>
+	</reg32>
 </group>
 
 <!-- Pre-Pascal variants -->

--- a/rnndb/memory/gf100_pbfb.xml
+++ b/rnndb/memory/gf100_pbfb.xml
@@ -144,6 +144,8 @@
 	<use-group name="gf100_pbfb"/>
 </array>
 
+<array name="PBFB_MC" offset="0x11d000" stride="0x1000" length="3" variants="GF100-" />
+
 </domain>
 
 </database>


### PR DESCRIPTION
Pascal and later generations had changes to framebuffer partition addressing (FBPA).

```
  These MMIO ranges have been moved and expanded from 0x1000 to 0x4000 in size:

  Name                Old Range               New Range
  NV_PFB_FBPA         0x10F000 (0x1000)       0x9A0000 (0x4000)
  NV_PFB_FBPA[i]      0x110000+(i * 0x1000)   0x900000+(i * 0x4000)
  NV_PFB_FBPA_MC[i]   0x11D000+(i * 0x1000)   0x980000+(i * 0x4000)

  The number of NV_PFB_FBPA[i] ranges is increased to a maximum of 16.
  The number of NV_PFB_FBPA_MC[i] ranges remains 3.

  Memory partition sizing and programming is the same as in prior NVIDIA
  architectures.
```
Reflect these changes within rnndb.

Source:
  https://download.nvidia.com/open-gpu-doc/pascal/1/gp100-fbpa.txt
  https://nv-tegra.nvidia.com/gitweb/?p=linux-nvgpu.git;a=blob;f=drivers/gpu/nvgpu/include/nvgpu/hw/gp106/hw_fb_gp106.h;hb=refs/tags/tegra-l4t-r28.2