### PR TITLE
Improve ctxsw microcode support (FECS and GPCCS) v2

### DIFF
--- a/rnndb/falcon.xml
+++ b/rnndb/falcon.xml
@@ -68,6 +68,15 @@
 	<!-- always 1f? -->
 </bitset>
 
+<bitset name="uc_cpuctl">
+	<bitfield pos="0" name="RESET_TLB_TRIGGER"/>
+	<bitfield pos="1" name="START_TRIGGER"/>
+	<bitfield pos="2" name="RESET_UNK2_TRIGGER"/>
+	<bitfield pos="3" name="RESET_UNK3_TRIGGER"/>
+	<bitfield pos="4" name="STOPPED"/>
+	<bitfield pos="5" name="SLEEPING"/>
+</bitset>
+
 <group name="falcon_base">
 	<reg32 offset="0x000" name="INTR_TRIGGER" access="w" type="falcon_intr"/>
 	<reg32 offset="0x004" name="INTR_ACK" access="w" type="falcon_intr"/>
@@ -202,14 +211,7 @@
 		<bitfield pos="31" name="ENABLED"/>
 	</reg32>
 
-	<reg32 offset="0x100" name="UC_CTRL">
-		<bitfield pos="0" name="RESET_TLB_TRIGGER"/>
-		<bitfield pos="1" name="START_TRIGGER"/>
-		<bitfield pos="2" name="RESET_UNK2_TRIGGER"/>
-		<bitfield pos="3" name="RESET_UNK3_TRIGGER"/>
-		<bitfield pos="4" name="STOPPED"/>
-		<bitfield pos="5" name="SLEEPING"/>
-	</reg32>
+	<reg32 offset="0x100" name="UC_CTRL" type="uc_cpuctl"/>
 
 	<reg32 offset="0x104" name="ENTRY"/>
 
@@ -298,6 +300,9 @@
 		<bitfield pos="30" name="UAS" variants="GF119-"/> <!-- unified address space -->
 		<bitfield pos="31" name="UNK31" variants="GF119-"/> <!-- auto fill -->
 	</reg32>
+
+	<reg32 offset="0x130" name="UC_CTRL_ALIAS" type="uc_cpuctl" variants="GM107-"/> <!-- v5+ secretful? -->
+
 	<reg32 offset="0x134" name="UNK134" variants="GM107-"> <!-- v5+ secretful? -->
 		<!-- bits 3, default 3 -->
 	</reg32>

--- a/rnndb/graph/gf100_pgraph/ctxctl.xml
+++ b/rnndb/graph/gf100_pgraph/ctxctl.xml
@@ -253,6 +253,15 @@
 
 	<reg32 offset="0x8b0" name="BLCG1" variants="GK104-"/>
 
+	<reg32 offset="0xb00" name="CURRENT_CTX" variants="GM107-">
+		<bitfield low="0" high="29" name="CHAN" type="g80_channel"/>
+		<bitfield pos="31" name="VALID" type="boolean"/>
+	</reg32>
+	<reg32 offset="0xb04" name="NEW_CTX" variants="GM107-">
+		<bitfield low="0" high="29" name="CHAN" type="g80_channel"/>
+		<bitfield pos="31" name="VALID" type="boolean"/>
+	</reg32>
+
 	<reg32 offset="0xc00" name="ENGINE_STATUS">
 		<bitfield pos="0" name="CHSW_PENDING"/>
 		<bitfield pos="1" name="CHAN_VALID"/>

--- a/rnndb/graph/gf100_pgraph/ctxctl.xml
+++ b/rnndb/graph/gf100_pgraph/ctxctl.xml
@@ -95,6 +95,8 @@
 	<reg32 offset="0x500" name="WRCMD_DATA"/>
 	<reg32 offset="0x504" name="WRCMD_CMD"/>
 
+	<reg32 offset="0x60c" name="MAJOR_REV_ID"/>
+
 	<reg32 offset="0x620" name="NEW_CAPS">
 		<bitfield low="0" high="7" name="CODE_SIZE" shr="8"/>
 		<bitfield low="8" high="15" name="DATA_SIZE" shr="8"/>

--- a/rnndb/graph/gf100_pgraph/ctxctl.xml
+++ b/rnndb/graph/gf100_pgraph/ctxctl.xml
@@ -138,9 +138,12 @@
 	<reg32 offset="0x730" name="MMIO_WRVAL"/>
 	<reg32 offset="0x74c" name="MMCTX_LOAD_COUNT"/> <!-- WTF? -->
 
-	<reg32 offset="0x800" name="CC_SCRATCH" length="8"/>
-	<reg32 offset="0x820" name="CC_SCRATCH_SET" length="8"/>
-	<reg32 offset="0x840" name="CC_SCRATCH_CLEAR" length="8"/>
+	<reg32 offset="0x800" name="CC_SCRATCH" length="8" variants="GF100:GM107"/>
+	<reg32 offset="0x800" name="CC_SCRATCH" length="16" variants="GM107-"/>
+	<reg32 offset="0x820" name="CC_SCRATCH_SET" length="8" variants="GF100:GM107"/>
+	<reg32 offset="0x8c0" name="CC_SCRATCH_SET" length="16" variants="GM107-"/>
+	<reg32 offset="0x840" name="CC_SCRATCH_CLEAR" length="8" variants="GF100:GM107"/>
+	<reg32 offset="0x840" name="CC_SCRATCH_CLEAR" length="16" variants="GM107-"/>
 	<reg32 offset="0x86c" name="UNK86C">
 		<bitfield pos="0" name="UNK0"/>
 		<bitfield pos="4" name="UNK4"/> <!-- affects trailer signal 0x2b -->

--- a/rnndb/graph/gf100_pgraph/ctxctl.xml
+++ b/rnndb/graph/gf100_pgraph/ctxctl.xml
@@ -100,6 +100,17 @@
 		<bitfield low="8" high="15" name="DATA_SIZE" shr="8"/>
 	</reg32>
 
+	<reg32 offset="0x658" name="FEATURE_OVERRIDE_ECC" variants="GP100-">
+		<bitfield pos="0"  name="SM_LRF"/>
+		<bitfield pos="3"  name="SM_LRF_OVERRIDE"/>
+		<bitfield pos="4"  name="SM_SHM"/>
+		<bitfield pos="7"  name="SM_SHM_OVERRIDE"/>
+		<bitfield pos="8"  name="TEX"/>
+		<bitfield pos="11" name="TEX_OVERRIDE"/>
+		<bitfield pos="12" name="LTC"/>
+		<bitfield pos="15" name="LTC_OVERRIDE"/>
+	</reg32>
+
 	<reg32 offset="0x700" name="MMCTX_SAVE_SWBASE" shr="8"/>
 	<reg32 offset="0x704" name="MMCTX_LOAD_SWBASE" shr="8"/>
 	<reg32 offset="0x710" name="MMCTX_BASE"/>


### PR DESCRIPTION
A set of improvements to ctxsw microcode support ported from `nvgpu`.

On my Pascal this just about covers all previously unknown ctxsw registers utilized by the blob.

v2: Reflects changes suggested by @koriakin 