### PR TITLE
Preliminary Falcon v6 documentation support

### DIFF
--- a/docs/envydis/index.rst
+++ b/docs/envydis/index.rst
@@ -113,6 +113,7 @@ Variant selection
   - fuc3: falcon version 3 [GT215 and up]
   - fuc4: falcon version 4 [GF119 and up, selected engines only]
   - fuc5: falcon version 5 [GK208 and up, selected engines only]
+  - fuc6: falcon version 6 [GP102 and up, selected engines only]
 
   For vuc:
 
@@ -153,9 +154,10 @@ Variant selection
   For falcon:
 
   - fuc0op: falcon version 0 exclusive opcodes [selected by fuc0]
-  - fuc3op: falcon version 3+ exclusive opcodes [selected by fuc3, fuc4, fuc5]
-  - fuc4op: falcon version 4+ exclusive opcodes [selected by fuc4, fuc5]
-  - fuc5op: falcon version 5+ exclusive opcodes [selected by fuc5]
+  - fuc3op: falcon version 3+ exclusive opcodes [selected by fuc3, fuc4, fuc5, fuc6]
+  - fuc4op: falcon version 4+ exclusive opcodes [selected by fuc4, fuc5, fuc6]
+  - fuc5op: falcon version 5+ exclusive opcodes [selected by fuc5, fuc6]
+  - fuc6op: falcon version 6+ exclusive opcodes [selected by fuc6]
   - pc24: 24-bit PC opcodes [selected by fuc4]
   - crypt: Cryptographic coprocessor opcodes [has to be manually selected]
 

--- a/docs/envydis/index.rst
+++ b/docs/envydis/index.rst
@@ -153,7 +153,9 @@ Variant selection
   For falcon:
 
   - fuc0op: falcon version 0 exclusive opcodes [selected by fuc0]
-  - fuc3op: falcon version 3+ exclusive opcodes [selected by fuc3, fuc4]
+  - fuc3op: falcon version 3+ exclusive opcodes [selected by fuc3, fuc4, fuc5]
+  - fuc4op: falcon version 4+ exclusive opcodes [selected by fuc4, fuc5]
+  - fuc5op: falcon version 5+ exclusive opcodes [selected by fuc5]
   - pc24: 24-bit PC opcodes [selected by fuc4]
   - crypt: Cryptographic coprocessor opcodes [has to be manually selected]
 

--- a/envydis/falcon.c
+++ b/envydis/falcon.c
@@ -30,6 +30,7 @@
 #define F_CRYPT	8
 #define F_FUC5P	0x10
 #define F_FUCOLD	0x20
+#define F_FUC6P	0x40
 
 /*
  * Code target fields
@@ -668,7 +669,8 @@ static void falcon_prep(struct disisa *isa) {
 	int f_crypt = vardata_add_feature(isa->vardata, "crypt", "Cryptographic coprocessor");
 	int f_fuc5op = vardata_add_feature(isa->vardata, "fuc5op", "v5+ opcodes");
 	int f_fucold = vardata_add_feature(isa->vardata, "fucold", "v0-v4 opcodes");
-	if (f_fuc0op == -1 || f_fuc3op == -1 || f_fuc4op == -1 || f_crypt == -1 || f_fuc5op == -1 || f_fucold == -1)
+	int f_fuc6op = vardata_add_feature(isa->vardata, "fuc6op", "v6+ opcodes");
+	if (f_fuc0op == -1 || f_fuc3op == -1 || f_fuc4op == -1 || f_crypt == -1 || f_fuc5op == -1 || f_fucold == -1 || f_fuc6op == -1 )
 		abort();
 	int vs_fucver = vardata_add_varset(isa->vardata, "version", "falcon version");
 	if (vs_fucver == -1)
@@ -677,7 +679,8 @@ static void falcon_prep(struct disisa *isa) {
 	int v_fuc3 = vardata_add_variant(isa->vardata, "fuc3", "falcon v3", vs_fucver);
 	int v_fuc4 = vardata_add_variant(isa->vardata, "fuc4", "falcon v4", vs_fucver);
 	int v_fuc5 = vardata_add_variant(isa->vardata, "fuc5", "falcon v5", vs_fucver);
-	if (v_fuc0 == -1 || v_fuc3 == -1 || v_fuc4 == -1 || v_fuc5 == -1)
+	int v_fuc6 = vardata_add_variant(isa->vardata, "fuc6", "falcon v6", vs_fucver);
+	if (v_fuc0 == -1 || v_fuc3 == -1 || v_fuc4 == -1 || v_fuc5 == -1 || v_fuc6 == -1)
 		abort();
 	vardata_variant_feature(isa->vardata, v_fuc0, f_fuc0op);
 	vardata_variant_feature(isa->vardata, v_fuc0, f_fucold);
@@ -689,6 +692,10 @@ static void falcon_prep(struct disisa *isa) {
 	vardata_variant_feature(isa->vardata, v_fuc5, f_fuc3op);
 	vardata_variant_feature(isa->vardata, v_fuc5, f_fuc4op);
 	vardata_variant_feature(isa->vardata, v_fuc5, f_fuc5op);
+	vardata_variant_feature(isa->vardata, v_fuc6, f_fuc3op);
+	vardata_variant_feature(isa->vardata, v_fuc6, f_fuc4op);
+	vardata_variant_feature(isa->vardata, v_fuc6, f_fuc5op);
+	vardata_variant_feature(isa->vardata, v_fuc6, f_fuc6op);
 	if (vardata_validate(isa->vardata))
 		abort();
 }

--- a/rnndb/falcon.xml
+++ b/rnndb/falcon.xml
@@ -273,6 +273,7 @@
 			<value value="3" name="V3"/>
 			<value value="4" name="V4"/>
 			<value value="5" name="V5"/>
+			<value value="6" name="V6"/>
 		</bitfield>
 		<bitfield low="4" high="5" name="CRYPT">
 			<value value="0" name="NONE"/>


### PR DESCRIPTION
Falcon version 6 has been seen on some Pascal-series engines (`PVDEC`, `PVENC`, `PSEC2` and `PGRAPH.CTXCTL`).

For now, note this within documentation and prepare the necessary bitfields for future support for any fuc6+ opcodes that might be encountered.