### PR TITLE
Improve readability of the HTML documentation

### DIFF
--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,0 +1,31 @@
+/* Overrides for the rtd theme. */
+
+/* Avoid wide tables with horizontal scrollbars by wrapping cell contents. */
+.wy-table-responsive table th,
+.wy-table-responsive table td {
+    white-space: normal;
+}
+
+/* Disable artificial width, only allowing tables to grow past that limit. */
+.wy-nav-content {
+    max-width: none;
+}
+div.section > :not(.wy-table-responsive):not(.section):not(.space),
+div.section .admonition {
+    max-width: 700px;
+}
+@media screen and (min-width: 800px) {
+    .wy-table-responsive table {
+        width: 700px;
+    }
+}
+
+/* For sufficiently large displays, try not to wrap cell contents.
+ * A horizontal scrollbar will be shown if necessary. */
+@media screen and (min-width: 1200px) {
+    /* Always try to wrap the first cell (due to the long line in the hw/mmio
+     * document), but prevent wrapping for subsequent cells. */
+    .wy-table-responsive table td:nth-child(n+2) {
+        white-space: nowrap;
+    }
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,8 +93,26 @@ primary_domain = 'envy'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'classic'
-html_style = '/classic.css'
+try:
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+    html_theme_options = {
+        'navigation_depth': 5,
+    }
+    html_context = {
+        'source_url_prefix': 'https://github.com/envytools/envytools/blob/master/docs/',
+#        'display_github': True,
+#        'github_user': 'envytools',
+#        'github_repo': 'envytools',
+#        'github_version': 'master',
+#        'conf_py_path': '/docs/',
+        'css_files': [
+            '_static/theme_overrides.css',
+        ],
+    }
+except ImportError:
+    sys.stderr.write('Warning: The Sphinx \'sphinx_rtd_theme\' HTML theme was not found. Make sure you have the theme installed to produce pretty HTML output. Falling back to the default theme.\n')
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/envy.py
+++ b/docs/envy.py
@@ -292,7 +292,7 @@ class Pos:
     def format_offset(self):
         res = hex(self.offset)
         for idx in self.indices:
-            res += '+{}*{:#x}'.format(idx.name, idx.stride)
+            res += ' +{}*{:#x}'.format(idx.name, idx.stride)
         return res
 
     def format_square(self):


### PR DESCRIPTION
tl;dr huge tables are unreadable, fix it using a new theme and extra CSS rules.

-    Switch to the Read the Docs Sphinx theme with overrides
    
    The current "classic" theme has a dark background. When combined with
    long tables such as the "NV3:G80 MMIO map" section in the mmio docs, the
    text is unreadable. Switch to the rtd theme (also used by kernel.org) to
    solve this.
    
    Add some additional styles to avoid cutting off tables at a width of
    700px, with large desktop monitors there is no need to waste space.
    Pay especially attention to the following large tables:
    
    - hw/gpu: Comparison table
    - hw/graph/intro: NV1/NV3 graph object types
    - hw/mmio: MMIO register ranges
    
    Tested with sphinx 1.7.9, sphinx_rtd_theme 0.4.1.

-    docs/eny.py: add space to trigger line wrapping
    
    The first (address) cell of the MMIO pages are unnecessarily long but
    cannot be wrapped. Insert a space to make word wrapping possible.
