### PR TITLE
demmt: Support NVRM_MTHD_DEVICE_GET_NUM_SLI_GPUS (0x00800280)

### DIFF
--- a/demmt/nvrm_decode_mthd.c
+++ b/demmt/nvrm_decode_mthd.c
@@ -104,9 +104,9 @@ static void decode_nvrm_mthd_device_get_classes(struct nvrm_mthd_device_get_clas
 		dump_mmt_buf_as_words_desc(data, nvrm_get_class_name);
 }
 
-static void decode_nvrm_mthd_device_unk0280(struct nvrm_mthd_device_unk0280 *m)
+static void decode_nvrm_mthd_device_get_num_subdevices(struct nvrm_mthd_device_get_num_subdevices *m)
 {
-	nvrm_print_x32(m, unk00);
+	nvrm_print_x32(m, cnt);
 	nvrm_print_ln();
 }
 
@@ -552,7 +552,7 @@ struct nvrm_mthd nvrm_mthds[] =
 	_(NVRM_MTHD_CONTEXT_UNK0201, struct nvrm_mthd_context_unk0201, decode_nvrm_mthd_context_unk0201),
 	_a(NVRM_MTHD_DEVICE_UNK1401, struct nvrm_mthd_device_unk1401, decode_nvrm_mthd_device_unk1401),
 	_a(NVRM_MTHD_DEVICE_GET_CLASSES, struct nvrm_mthd_device_get_classes, decode_nvrm_mthd_device_get_classes),
-	_(NVRM_MTHD_DEVICE_UNK0280, struct nvrm_mthd_device_unk0280, decode_nvrm_mthd_device_unk0280),
+	_(NVRM_MTHD_DEVICE_GET_NUM_SUBDEVICES, struct nvrm_mthd_device_get_num_subdevices, decode_nvrm_mthd_device_get_num_subdevices),
 	_(NVRM_MTHD_SUBDEVICE_GET_BUS_ID, struct nvrm_mthd_subdevice_get_bus_id, decode_nvrm_mthd_subdevice_get_bus_id),
 	_(NVRM_MTHD_SUBDEVICE_GET_CHIPSET, struct nvrm_mthd_subdevice_get_chipset, decode_nvrm_mthd_subdevice_get_chipset),
 	_(NVRM_MTHD_SUBDEVICE_GET_CHIPSET, struct nvrm_mthd_subdevice_get_chipset16, decode_nvrm_mthd_subdevice_get_chipset16),

--- a/demmt/nvrm_mthd.h
+++ b/demmt/nvrm_mthd.h
@@ -118,10 +118,10 @@ struct nvrm_mthd_device_get_classes {
 };
 #define NVRM_MTHD_DEVICE_GET_CLASSES 0x00800201
 
-struct nvrm_mthd_device_unk0280 {
-	uint32_t unk00; /* out */
+struct nvrm_mthd_device_get_num_subdevices {
+	uint32_t cnt; /* out */
 };
-#define NVRM_MTHD_DEVICE_UNK0280 0x00800280
+#define NVRM_MTHD_DEVICE_GET_NUM_SUBDEVICES 0x00800280
 
 struct nvrm_mthd_device_set_persistence_mode {
 	uint32_t mode;


### PR DESCRIPTION
Method reports number of available, linked GPUs. On systems with multiple physical GPUs, where SLI is disabled, the method will return a count of 1.