### PR TITLE
nvbios/conn: Add USB Type-C connector type

### DIFF
--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -727,6 +727,7 @@ enum envy_bios_conn_type {
 	ENVY_BIOS_CONN_DMS59_DP0		= 0x64,
 	ENVY_BIOS_CONN_DMS59_DP1		= 0x65,
 	ENVY_BIOS_CONN_WFD			= 0x70,
+	ENVY_BIOS_CONN_USB_C     		= 0x71,
 	ENVY_BIOS_CONN_UNUSED			= 0xff,
 };
 

--- a/nvbios/conn.c
+++ b/nvbios/conn.c
@@ -129,6 +129,7 @@ static struct enum_val conn_types[] = {
 	{ ENVY_BIOS_CONN_DMS59_DP0,		"DMS59_DP0" },
 	{ ENVY_BIOS_CONN_DMS59_DP1,		"DMS59_DP1" },
 	{ ENVY_BIOS_CONN_WFD,			"WFD" },
+	{ ENVY_BIOS_CONN_USB_C,      		"USB_C" },
 	{ ENVY_BIOS_CONN_UNUSED,		"UNUSED" },
 	{ 0 },
 };


### PR DESCRIPTION
USB Type-C connectors have been added to Turing GPUs.
This output may be utilized for next-generation Virtual Reality headsets.