### PR TITLE
nvbios/bit: Correct size of BIT Header version field to 16-bits

### DIFF
--- a/nvbios/bios.c
+++ b/nvbios/bios.c
@@ -187,7 +187,7 @@ int envy_bios_parse (struct envy_bios *bios) {
 		bios_u16(bios, 0x54, &bios->subsystem_vendor);
 		bios_u16(bios, 0x56, &bios->subsystem_device);
 		if (envy_bios_parse_bit(bios))
-			ENVY_BIOS_ERR("Failed to parse BIT table at 0x%04x version %d\n", bios->bit.offset, bios->bit.version);
+			ENVY_BIOS_ERR("Failed to parse BIT table at 0x%04x version %d.%d\n", bios->bit.offset, bios->bit.version >> 8, bios->bit.version & 0xff);
 		if (envy_bios_parse_dcb(bios))
 			ENVY_BIOS_ERR("Failed to parse DCB table at 0x%04x version %d.%d\n", bios->dcb.offset, bios->dcb.version >> 4, bios->dcb.version & 0xf);
 		if (bios->dcb.version >= 0x20) {

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -81,7 +81,7 @@ struct envy_bios_bit_entry {
 struct envy_bios_bit {
 	uint16_t offset;
 	uint8_t valid;
-	uint8_t version;
+	uint16_t version;
 	uint8_t hlen;
 	uint8_t entriesnum;
 	uint8_t rlen;

--- a/nvbios/bit.c
+++ b/nvbios/bit.c
@@ -72,7 +72,7 @@ int envy_bios_parse_bit (struct envy_bios *bios) {
 	if (!bit->offset)
 		return 0;
 	int err = 0;
-	err |= bios_u8(bios, bit->offset+7, &bit->version);
+	err |= bios_u16(bios, bit->offset+6, &bit->version);
 	err |= bios_u8(bios, bit->offset+8, &bit->hlen);
 	err |= bios_u8(bios, bit->offset+9, &bit->rlen);
 	err |= bios_u8(bios, bit->offset+10, &bit->entriesnum);
@@ -95,10 +95,10 @@ int envy_bios_parse_bit (struct envy_bios *bios) {
 	int wanthlen = 12;
 	int wantrlen = 6;
 	switch (bit->version) {
-		case 1:
+		case 0x0100:
 			break;
 		default:
-			ENVY_BIOS_ERR("Unknown BIT table version %d\n", bit->version);
+			ENVY_BIOS_ERR("Unknown BIT table version %d.%d\n", bit->version >> 8, bit->version & 0xff);
 			return -EINVAL;
 	}
 	if (bit->hlen < wanthlen) {
@@ -153,10 +153,10 @@ void envy_bios_print_bit (struct envy_bios *bios, FILE *out, unsigned mask) {
 	if (!bit->offset || !(mask & ENVY_BIOS_PRINT_BMP_BIT))
 		return;
 	if (!bit->valid) {
-		fprintf(out, "Failed to parse BIT table at 0x%04x version %d\n\n", bit->offset, bit->version);
+		fprintf(out, "Failed to parse BIT table at 0x%04x version %d.%d\n\n", bit->offset, bit->version >> 8, bit->version & 0xff);
 		return;
 	}
-	fprintf(out, "BIT table at 0x%04x version %d", bit->offset, bit->version);
+	fprintf(out, "BIT table at 0x%04x version %d.%d", bit->offset, bit->version >> 8, bit->version & 0xff);
 	fprintf(out, "\n");
 	envy_bios_dump_hex(bios, out, bit->offset, bit->hlen, mask);
 	int i;


### PR DESCRIPTION
Version field of BIT Header is actually 16 bits, with the major version in the upper byte, minor version in the lower byte.

Until now, envytools was only reading the major version number.

Verified no other output of `nvbios` changed:
```diff
$ diff -u vbios.txt.before vbios.txt.after 
--- vbios.txt.before	2018-11-24 12:39:00.830658504 -0500
+++ vbios.txt.after	2018-11-24 12:39:30.486864194 -0500
@@ -36,7 +36,7 @@
 
 Subsystem id: 0x0000:0x0000
 
-BIT table at 0x0210 version 1
+BIT table at 0x0210 version 1.0
 BIT table '2' version 1 at 0x0292 length 0x0004
 BIT table 'B' version 2 at 0x029e length 0x0025
 BIT table 'C' version 2 at 0x02c3 length 0x001c
```