### PR TITLE
nvbios: PCI Expansion ROM parsing improvements

### DIFF
--- a/nvbios/bios.c
+++ b/nvbios/bios.c
@@ -95,7 +95,7 @@ broken_part:
 		bios_u8(bios, curpos+pcir_offset+0x15, &bios->parts[num].pcir_indi);
 		bios->parts[num].pcir_offset = pcir_offset;
 		bios->parts[num].length = pcir_ilen * 0x200;
-		if (bios->parts[num].pcir_code_type == 0) {
+		if (bios->parts[num].pcir_code_type == ENVY_BIOS_PCIR_INTEL_X86) {
 			int i;
 			uint8_t sum = 0;
 			uint8_t init_ilen;

--- a/nvbios/bios.c
+++ b/nvbios/bios.c
@@ -66,6 +66,12 @@ broken_part:
 			goto broken_part;
 		if (curpos + pcir_ilen * 0x200 > bios->origlength)
 			goto broken_part;
+		/* "The PCI Data Structure ... must be DWORD aligned."
+		 *  PCI Specification, Revision 2.2. (1998), pg 207
+		 *  PCI Firmware Specification, Revision 3.0 (2005), pg 71
+		 */
+		if (pcir_offset & 0x3)
+			goto broken_part;
 		envy_bios_block(bios, curpos, 2, "SIG", num);
 		envy_bios_block(bios, curpos+0x18, 2, "PCIR_PTR", num);
 		switch (pcir_rev) {

--- a/nvbios/bios.c
+++ b/nvbios/bios.c
@@ -60,7 +60,7 @@ broken_part:
 			goto broken_part;
 		if (curpos + pcir_ilen * 0x200 > bios->origlength)
 			goto broken_part;
-		envy_bios_block(bios, curpos, 3, "SIG", num);
+		envy_bios_block(bios, curpos, 2, "SIG", num);
 		envy_bios_block(bios, curpos+0x18, 2, "PCIR_PTR", num);
 		envy_bios_block(bios, curpos+pcir_offset, 0x18, "PCIR", num);
 		if (!(pcir_indi & 0x80))
@@ -101,9 +101,20 @@ broken_part:
 			uint8_t init_ilen;
 			bios_u8(bios, curpos + 2, &init_ilen);
 			bios->parts[num].init_length = init_ilen * 0x200;
+			envy_bios_block(bios, curpos + 2, 1, "SIG_LENGTH", num);
+			envy_bios_block(bios, curpos + 3, 3, "SIG_X86_INIT_PTR", num);
+			envy_bios_block(bios, curpos + 6, 18, "RESERVED", num);
 			for (i = 0; i < bios->parts[num].init_length; i++)
 				sum += bios->data[curpos + i];
 			bios->parts[num].chksum_pass = (sum == 0);
+		} else if (bios->parts[num].pcir_code_type == ENVY_BIOS_PCIR_EFI) {
+			uint16_t init_ilen;
+			uint32_t efi_sig;
+			bios_u16(bios, curpos + 2, &init_ilen);
+			bios->parts[num].init_length = init_ilen * 0x200;
+			envy_bios_block(bios, curpos + 2, 2, "SIG_LENGTH", num);
+			bios_u32(bios, curpos + 4, &efi_sig);
+			bios->parts[num].chksum_pass = (efi_sig == 0x000ef1);
 		}
 		curpos += bios->parts[num].length;
 	}

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -49,6 +49,15 @@ struct envy_bios_part {
 	int chksum_pass;
 };
 
+enum envy_bios_pcir_code_type {
+	ENVY_BIOS_PCIR_INTEL_X86 = 0x00,
+	ENVY_BIOS_PCIR_INTEL_OPENFIRMWARE,
+	ENVY_BIOS_PCIR_HP_PA_RISC,
+	// Included in PCI Firmware Specification, Rev. 3.0+
+	ENVY_BIOS_PCIR_EFI,
+	ENVY_BIOS_PCIR_UNUSED = 0xff
+};
+
 enum envy_bios_type {
 	ENVY_BIOS_TYPE_UNKNOWN = 0,
 	ENVY_BIOS_TYPE_NV01,

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -35,6 +35,10 @@
 struct envy_bios_part {
 	unsigned int start;
 	unsigned int length;
+	unsigned int efi_offset;
+	uint16_t efi_subsystem_type;
+	uint16_t efi_machine_type;
+	uint16_t efi_compression_type;
 	unsigned int pcir_offset;
 	uint16_t pcir_vendor;
 	uint16_t pcir_device;

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -49,6 +49,11 @@ struct envy_bios_part {
 	int chksum_pass;
 };
 
+enum envy_bios_pcir_rev_type {
+	ENVY_BIOS_PCIR_REV_2DOT2 = 0x00,
+	ENVY_BIOS_PCIR_REV_3DOT0 = 0x03,
+};
+
 enum envy_bios_pcir_code_type {
 	ENVY_BIOS_PCIR_INTEL_X86 = 0x00,
 	ENVY_BIOS_PCIR_INTEL_OPENFIRMWARE,

--- a/nvbios/bios.h
+++ b/nvbios/bios.h
@@ -39,12 +39,16 @@ struct envy_bios_part {
 	uint16_t pcir_vendor;
 	uint16_t pcir_device;
 	uint16_t pcir_vpd;
+	uint16_t pcir_device_list_offset;
 	uint16_t pcir_len;
 	uint8_t pcir_rev;
 	uint8_t pcir_class[3];
 	uint16_t pcir_code_rev;
 	uint8_t pcir_code_type;
 	uint8_t pcir_indi;
+	uint16_t pcir_mrtil;
+	uint16_t pcir_config_util_offset;
+	uint16_t pcir_dmtf_clp_offset;
 	unsigned int init_length;
 	int chksum_pass;
 };

--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -115,10 +115,18 @@ static void print_pcir(struct envy_bios *bios, FILE *out, unsigned mask) {
 		envy_bios_dump_hex(bios, out, bios->parts[i].start + bios->parts[i].pcir_offset, bios->parts[i].pcir_len, mask);
 		fprintf(out, "PCI device: 0x%04x:0x%04x, class 0x%02x%02x%02x\n", bios->parts[i].pcir_vendor, bios->parts[i].pcir_device, bios->parts[i].pcir_class[2], bios->parts[i].pcir_class[1], bios->parts[i].pcir_class[0]);
 		if (bios->parts[i].pcir_vpd)
-			fprintf(out, "VPD: 0x%x\n", bios->parts[i].pcir_vpd);
+			fprintf(out, "PCIR VPD: 0x%x\n", bios->parts[i].pcir_vpd);
+		if (bios->parts[i].pcir_device_list_offset)
+			fprintf(out, "PCI device list pointer: 0x%04x\n", bios->parts[i].pcir_device_list_offset);
 		const char *code_type = find_enum(pcir_code_types, bios->parts[i].pcir_code_type);
 		fprintf(out, "PCIR code type: 0x%02x [%s], rev 0x%04x\n", bios->parts[i].pcir_code_type, code_type, bios->parts[i].pcir_code_rev);
 		fprintf(out, "PCIR indicator: 0x%02x\n", bios->parts[i].pcir_indi);
+		if (bios->parts[i].pcir_mrtil)
+			fprintf(out, "PCIR maximum run-time image length: 0x%04x\n", bios->parts[i].pcir_mrtil);
+		if (bios->parts[i].pcir_config_util_offset)
+			fprintf(out, "PCIR configuration utility code header pointer: 0x%04x\n", bios->parts[i].pcir_config_util_offset);
+		if (bios->parts[i].pcir_dmtf_clp_offset)
+			fprintf(out, "PCIR DMTF CLP entry point pointer: 0x%04x\n", bios->parts[i].pcir_dmtf_clp_offset);
 	}
 	if (bios->broken_part)
 		fprintf(out, "\nWARN: Couldn't read part %d!\n", bios->partsnum);

--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -83,6 +83,12 @@ static struct enum_val pcir_code_types[] = {
 	{ 0 },
 };
 
+static struct enum_val pcir_rev_types[] = {
+	{ ENVY_BIOS_PCIR_REV_2DOT2, "2.2" },
+	{ ENVY_BIOS_PCIR_REV_3DOT0, "3.0+" },
+	{ 0 },
+};
+
 static void print_pcir(struct envy_bios *bios, FILE *out, unsigned mask) {
 	int i;
 	if (!(mask & ENVY_BIOS_PRINT_PCIR))
@@ -104,7 +110,8 @@ static void print_pcir(struct envy_bios *bios, FILE *out, unsigned mask) {
 		fprintf(out, "ROM Header PCIR pointer: 0x%04x\n", bios->parts[i].pcir_offset);
 
 		// PCI Data Structure
-		fprintf(out, "PCIR [rev 0x%02x]:\n", bios->parts[i].pcir_rev);
+		const char *rev_type = find_enum(pcir_rev_types, bios->parts[i].pcir_rev);
+		fprintf(out, "PCIR [rev 0x%02x [%s]]:\n", bios->parts[i].pcir_rev, rev_type);
 		envy_bios_dump_hex(bios, out, bios->parts[i].start + bios->parts[i].pcir_offset, bios->parts[i].pcir_len, mask);
 		fprintf(out, "PCI device: 0x%04x:0x%04x, class 0x%02x%02x%02x\n", bios->parts[i].pcir_vendor, bios->parts[i].pcir_device, bios->parts[i].pcir_class[2], bios->parts[i].pcir_class[1], bios->parts[i].pcir_class[0]);
 		if (bios->parts[i].pcir_vpd)

--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -107,6 +107,17 @@ static void print_pcir(struct envy_bios *bios, FILE *out, unsigned mask) {
 		}
 		fprintf(out, "PCI Expansion ROM Header:\n");
 		envy_bios_dump_hex(bios, out, bios->parts[i].start, 0x1A, mask);
+
+		if (bios->parts[i].efi_offset)
+			fprintf(out, "ROM Header EFI pointer: 0x%04x (subsystem: 0x%04x, machine: 0x%04x, compression: 0x%04x)\n",
+			             bios->parts[i].efi_offset,
+			             bios->parts[i].efi_subsystem_type,
+			             bios->parts[i].efi_machine_type,
+			             bios->parts[i].efi_compression_type);
+
+		// EFI Image Format
+		// TODO: parse and print the EFI Image
+
 		fprintf(out, "ROM Header PCIR pointer: 0x%04x\n", bios->parts[i].pcir_offset);
 
 		// PCI Data Structure

--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -90,15 +90,20 @@ static void print_pcir(struct envy_bios *bios, FILE *out, unsigned mask) {
 	fprintf(out, "BIOS size 0x%x [orig: 0x%x], %d valid parts:\n", bios->length, bios->origlength, bios->partsnum);
 	for (i = 0; i < bios->partsnum; i++) {
 		fprintf(out, "\n");
-		if (bios->parts[i].pcir_code_type == ENVY_BIOS_PCIR_INTEL_X86) {
+		// PCI Expansion ROM Header
+		if (bios->parts[i].pcir_code_type == ENVY_BIOS_PCIR_INTEL_X86 ||
+		    bios->parts[i].pcir_code_type == ENVY_BIOS_PCIR_EFI) {
 			fprintf(out, "BIOS part %d at 0x%x size 0x%x [init: 0x%x]. Sig:\n", i, bios->parts[i].start, bios->parts[i].length, bios->parts[i].init_length);
-			envy_bios_dump_hex(bios, out, bios->parts[i].start, 3, mask);
 			if (!bios->parts[i].chksum_pass)
 				fprintf(out, "WARN: checksum fail\n");
 		} else {
 			fprintf(out, "BIOS part %d at 0x%x size 0x%x. Sig:\n", i, bios->parts[i].start, bios->parts[i].length);
-			envy_bios_dump_hex(bios, out, bios->parts[i].start, 2, mask);
 		}
+		fprintf(out, "PCI Expansion ROM Header:\n");
+		envy_bios_dump_hex(bios, out, bios->parts[i].start, 0x1A, mask);
+		fprintf(out, "ROM Header PCIR pointer: 0x%04x\n", bios->parts[i].pcir_offset);
+
+		// PCI Data Structure
 		fprintf(out, "PCIR [rev 0x%02x]:\n", bios->parts[i].pcir_rev);
 		envy_bios_dump_hex(bios, out, bios->parts[i].start + bios->parts[i].pcir_offset, bios->parts[i].pcir_len, mask);
 		fprintf(out, "PCI device: 0x%04x:0x%04x, class 0x%02x%02x%02x\n", bios->parts[i].pcir_vendor, bios->parts[i].pcir_device, bios->parts[i].pcir_class[2], bios->parts[i].pcir_class[1], bios->parts[i].pcir_class[0]);

--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -74,6 +74,15 @@ void envy_bios_dump_hex (struct envy_bios *bios, FILE *out, unsigned int start, 
 		}
 }
 
+static struct enum_val pcir_code_types[] = {
+	{ ENVY_BIOS_PCIR_INTEL_X86,          "INTEL_X86" },
+	{ ENVY_BIOS_PCIR_INTEL_OPENFIRMWARE, "OPENFIRMWARE" },
+	{ ENVY_BIOS_PCIR_HP_PA_RISC,         "HP_PA_RISC" },
+	{ ENVY_BIOS_PCIR_EFI,                "EFI" },
+	{ ENVY_BIOS_PCIR_UNUSED,             "UNK" },
+	{ 0 },
+};
+
 static void print_pcir(struct envy_bios *bios, FILE *out, unsigned mask) {
 	int i;
 	if (!(mask & ENVY_BIOS_PRINT_PCIR))
@@ -81,7 +90,7 @@ static void print_pcir(struct envy_bios *bios, FILE *out, unsigned mask) {
 	fprintf(out, "BIOS size 0x%x [orig: 0x%x], %d valid parts:\n", bios->length, bios->origlength, bios->partsnum);
 	for (i = 0; i < bios->partsnum; i++) {
 		fprintf(out, "\n");
-		if (bios->parts[i].pcir_code_type == 0) {
+		if (bios->parts[i].pcir_code_type == ENVY_BIOS_PCIR_INTEL_X86) {
 			fprintf(out, "BIOS part %d at 0x%x size 0x%x [init: 0x%x]. Sig:\n", i, bios->parts[i].start, bios->parts[i].length, bios->parts[i].init_length);
 			envy_bios_dump_hex(bios, out, bios->parts[i].start, 3, mask);
 			if (!bios->parts[i].chksum_pass)
@@ -95,7 +104,8 @@ static void print_pcir(struct envy_bios *bios, FILE *out, unsigned mask) {
 		fprintf(out, "PCI device: 0x%04x:0x%04x, class 0x%02x%02x%02x\n", bios->parts[i].pcir_vendor, bios->parts[i].pcir_device, bios->parts[i].pcir_class[2], bios->parts[i].pcir_class[1], bios->parts[i].pcir_class[0]);
 		if (bios->parts[i].pcir_vpd)
 			fprintf(out, "VPD: 0x%x\n", bios->parts[i].pcir_vpd);
-		fprintf(out, "Code type 0x%02x, rev 0x%04x\n", bios->parts[i].pcir_code_type, bios->parts[i].pcir_code_rev);
+		const char *code_type = find_enum(pcir_code_types, bios->parts[i].pcir_code_type);
+		fprintf(out, "PCIR code type: 0x%02x [%s], rev 0x%04x\n", bios->parts[i].pcir_code_type, code_type, bios->parts[i].pcir_code_rev);
 		fprintf(out, "PCIR indicator: 0x%02x\n", bios->parts[i].pcir_indi);
 	}
 	if (bios->broken_part)


### PR DESCRIPTION
This series reflects cleanups and improvements to the PCI Expansion ROM parsing against current specifications. Some highlights:
* Fully document Legacy and EFI PCI Expansion ROM and PCIR Data Structure (pcir) fields.
* Support changes introduced with PCI Specification 3.0+.
* Support EFI PCI Expansion ROM headers (e.g. multi-part VBIOS').
* Better report Intel x86 PC-AT, OpenFirmware, and EFI code types; improve validation; and better track used blocks.

As an example, the output changes on a multi-part (Intel x86 PC-AT compatible and EFI) VBIOS are:
```diff
$ diff -u vbios.txt.before vbios.txt.after 
--- vbios.txt.before	2018-11-24 21:34:40.009202055 -0500
+++ vbios.txt.after	2018-11-24 21:34:29.437135750 -0500
@@ -23,19 +23,26 @@
 BIOS size 0x20400 [orig: 0x100000], 2 valid parts:
 
 BIOS part 0 at 0x0 size 0xf600 [init: 0xf600]. Sig:
-PCIR [rev 0x00]:
+PCI Expansion ROM Header:
+ROM Header PCIR pointer: 0x0190
+PCIR [rev 0x00 [2.2]]:
 PCI device: 0x10de:0x1381, class 0x030000
-Code type 0x00, rev 0x0001
+PCIR code type: 0x00 [INTEL_X86], rev 0x0001
 PCIR indicator: 0x00
 
-BIOS part 1 at 0xf600 size 0x10e00. Sig:
-PCIR [rev 0x03]:
+BIOS part 1 at 0xf600 size 0x10e00 [init: 0x10e00]. Sig:
+PCI Expansion ROM Header:
+ROM Header EFI pointer: 0x0050 (subsystem: 0x000b, machine: 0x8664, compression: 0x0001)
+ROM Header PCIR pointer: 0x001c
+PCIR [rev 0x03 [3.0+]]:
 PCI device: 0x10de:0x1381, class 0x030000
-Code type 0x03, rev 0x0000
+PCIR code type: 0x03 [EFI], rev 0x0000
 PCIR indicator: 0x80
 
-0x00000000:0x00000003 SIG[0]
-0x00000003:0x00000018 ???
+0x00000000:0x00000002 SIG[0]
+0x00000002:0x00000003 SIG_LENGTH[0]
+0x00000003:0x00000006 SIG_X86_INIT_PTR[0]
+0x00000006:0x00000018 RESERVED[0]
 0x00000018:0x0000001a PCIR_PTR[0]
 0x0000001a:0x00000036 ???
 0x00000036:0x00000038 DCB_PTR
@@ -87,11 +94,14 @@
 0x00008cc9:0x0000e4be ???
 0x0000e4be:0x0000e4df IUNK21
 0x0000e4df:0x0000f600 ???
-0x0000f600:0x0000f603 SIG[1]
-0x0000f603:0x0000f618 ???
+0x0000f600:0x0000f602 SIG[1]
+0x0000f602:0x0000f604 SIG_LENGTH[1]
+0x0000f604:0x0000f60e SIG_EFI[1]
+0x0000f60e:0x0000f616 RESERVED[1]
+0x0000f616:0x0000f618 EFI_PTR[1]
 0x0000f618:0x0000f61a PCIR_PTR[1]
 0x0000f61a:0x0000f61c ???
-0x0000f61c:0x0000f634 PCIR[1]
-0x0000f634:0x00015074 ???
+0x0000f61c:0x0000f638 PCIR[1]
+0x0000f638:0x00015074 ???
 0x00015074:0x000150ac MMIOINIT
```
As with any parsing code, pointer tracking has been tested with `valgrind`, `nvbios`' used block tracking to ensure no overlaps, and VBIOSes from a range of modern GPUs.

This series should also assist future Turing work, where more complex usage of multi-part EFI VBIOSes has been seen.