### PR TITLE
nvbios: Optionally dump hex contents of unknown blocks

### DIFF
--- a/nvbios/print.c
+++ b/nvbios/print.c
@@ -478,6 +478,7 @@ void envy_bios_print (struct envy_bios *bios, FILE *out, unsigned mask) {
 			unsigned end = start + bios->blocks[i].len;
 			if (start > last) {
 				fprintf(out, "0x%08x:0x%08x ???\n", last, start);
+				envy_bios_dump_hex(bios, out, last, (start - last), mask);
 			}
 			if (start < last) {
 				fprintf(out, "overlap detected!\n");


### PR DESCRIPTION
nvbios provides a handy feature to print a summary of the tagged, and untagged blocks
within a VBIOS file with '-b'. Whilst the blocks need to be tagged within nvbios as new
functionality is reverse engineered and understood -- this is currently fairly complete.

Untagged blocks are shown as '???' with a start and end offset within the VBIOS.

This patch optionally adds the ability to dump the hex values of any untagged blocks with
the standard '-vv' which increases verbosity. e.g.
```bash
$ ./nvbios/nvbios -b -p info -vv <vbios.rom>

HWINFO ext sig mismatch [0x00]
INFO: BIOS version 0x86.07.3e.00.1c from 02/08/17 for NV137 [GP107]
INFO: features MOBILE, unk07 0xb4 0xe3 0x4a 0x01 0x09 0xf0, unk23 0x12, unk24 0x01,
unk25 0x10, unk28 0x00 0x80 0x01 0x00 0x00 0x00 0x00 0x00, unk30 725029040001,
unk3c 0x00 0x00 0x00 0x00 0x00 0x00 0x1e 0x00
...

0x00000000:0x00000003 SIG[0]
0x00000003:0x00000018 ???
0x00000003: eb 4b 37 34 30 30 e9 4c 19 77 cc 56 49 44 45 4f
0x00000013: 20 0d 00 00 00
0x00000018:0x0000001a PCIR_PTR[0]
0x0000001a:0x00000036 ???
0x0000001a: 6c 19 00 00 49 42 4d 20 56 47 41 20 43 6f 6d 70
0x0000002a: 61 74 69 62 6c 65 01 00 00 00 00 00
0x00000036:0x00000038 DCB_PTR
0x00000038:0x00000054 ???
0x00000038: 30 33 2f 32 30 2f 31 37 00 00 00 00 00 00 00 00
0x00000048: 80 10 50 00 5f f0 00 00 e9 4b 29 00
0x00000054:0x00000058 HWINFO
0x00000058:0x000001a0 ???
0x00000058: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
0x00000068: 00 00 00 00 00 00 00 00 00 00 00 00 00 e9 f3 42
...
0x00000178: b1 90 8b df b9 90 8d df af 8d 90 9b 8a 9c 8b 96
0x00000188: 90 91 df aa 8c 9a f2 f5 ff 00 00 00 00 00 00 00
0x00000198: 00 00 00 00 00 00 00 00
0x000001a0:0x000001b8 PCIR[0]
0x000001b8:0x00000210 ???
0x000001b8: 00 00 00 00 2e 8b c0 90 4e 50 44 45 01 01 14 00
...
0x00000208: 00 00 00 00 00 00 00 00
0x00000210:0x00000282 BIT
0x00000282:0x00000292 ???
0x00000282: 00 00 58 04 07 4a cd 65 40 71 90 cd 00 00 00 00
0x00000292:0x00000296 BIT '2'
0x00000296:0x0000029e ???
0x00000296: 00 00 00 00 00 00 00 00
0x0000029e:0x000002c3 BIT 'B'
0x000002c3:0x000002df BIT 'C'
0x000002df:0x000002e3 BIT 'D'
0x000002e3:0x00000305 BIT 'I'
0x00000305:0x0000031e BIT 'M'
0x0000031e:0x000003ba BIT 'P'
0x000003ba:0x000003d2 BIT 'S'
0x000003d2:0x000003d4 BIT 'T'
0x000003d4:0x000003d9 BIT 'U'
0x000003d9:0x000003df BIT 'V'
0x000003df:0x000003e7 BIT 'x'
0x000003e7:0x000003e9 BIT 'd'
0x000003e9:0x000003ed BIT 'p'
0x000003ed:0x000003fa BIT 'u'
0x000003fa:0x000003fc ???
0x000003fa: 00 00
0x000003fc:0x00000458 BIT 'i'
```