### PR TITLE
nvbios: Add Pascal family devinit opcodes

### DIFF
--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -708,6 +708,11 @@ void printscript (uint16_t soff) {
 				printf ("I2C_IF_LONG\tI2C[0x%02x][0x%02x][0x%02x:0x%02x] & 0x%02x == 0x%02x\n", bios->data[soff+1], bios->data[soff+2], bios->data[soff+4], bios->data[soff+3], bios->data[soff+5], bios->data[soff+6]);
 				soff += 7;
 				break;
+			case 0x9e:
+				printcmd (soff, 1);
+				printf ("UNK9E\n");
+				soff++;
+				break;
 			case 0xa9:
 				printcmd (soff, 2);
 				printf ("GPIO_NE\n");

--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -733,6 +733,12 @@ void printscript (uint16_t soff) {
 				printf("UNKAA\n");
 				soff += 4;
 				break;
+			case 0xac:
+				// Seen operating on PFUSE.FUSES+0xb1c and PFUSE.FUSES+0x2f4
+				printcmd (soff, 13);
+				printf ("UNKAC\tR[0x%06x] = 0x%08x, 0x%08x\n", le32(soff+1), le32(soff+5), le32(soff+9));
+				soff += 13;
+				break;
 			case 0xaf:
 				cnt = bios->data[soff+2];
 				uint8_t iters = bios->data[soff+1];


### PR DESCRIPTION
Two BIOS devinit opcodes that were introduced with Pascal:
* **0x9e**: UNK9E: Single byte, no parameters.
* **0xac**: UNKAC: Seen operating on PFUSE.FUSES+0xb1c and PFUSE.FUSES+0x2f4. Examples below with the inferred structure of the register and (mask, value) pair.

```
UNKAC	R[0x0213f4] = 0x00000001, 0x00000001
...
UNKAC	R[0x021c1c] = 0x00000000, 0xffffffff
```

Verified with NV132, NV134, NV136, NV137 and NV138. No prior occurrences of these two opcodes within the vbios corpus repository.