### PR TITLE
nvbios: Document INIT_MEM_INFO devinit opcode (0x9E)

### DIFF
--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -736,7 +736,7 @@ void printscript (uint16_t soff) {
 				break;
 			case 0x9e:
 				printcmd (soff, 1);
-				printf ("UNK9E\n");
+				printf ("MEM_INFO\n");
 				soff++;
 				break;
 			case 0xa9:


### PR DESCRIPTION
Forces the Memory Information Table entry look-up.

This function forces the init processor to execute entry look-up in the Memory Information Table, which includes reading Memory Strap and/or Memory ID from hardware registers and searching for the matching entry. The memory information is then cached for fast retrieval in subsequent operations.
Upon return from the Memory Information Table entry look-up, the devinit engine continues processing.

This opcode allows for clear indication of when to read the Memory Strap and Memory ID registers, which may be manipulated by other devinit opcodes, so that all engines can be instructed to process the Memory Information Table in an identical sequence.

Present on [core70,)

Source:
- https://download.nvidia.com/open-gpu-doc/Devinit/1/devinit.xml#INIT_MEM_INFO