### PR TITLE
nvbios: Document INIT_RESET_BEGUN and INIT_RESET_END

### DIFF
--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -623,8 +623,21 @@ void printscript (uint16_t soff) {
 				soff++;
 				break;
 			case 0x8d:
+				/*
+				 * Signal that the reset sequence has completed.
+				 *
+				 * This opcode signals that the software reset sequence has completed.
+				 * Ordinarily, no actual operations are performed by the opcode.
+				 * However it allows for possible software work arounds by devinit
+				 * engines in software agents other than the VBIOS, such as the resman,
+				 * FCODE, and EFI driver. This opcode is designed to be included in
+				 * the devinit script immediately after the NV_PMC_ENABLE register
+				 * has be written to take most of the engines out of the reset state.
+				 *
+				 * Present on [core6,)
+				 */
 				printcmd (soff, 1);
-				printf ("UNK8D\n");
+				printf ("RESET_END\n");
 				soff++;
 				break;
 			case 0x8e:

--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -605,8 +605,21 @@ void printscript (uint16_t soff) {
 				}
 				break;
 			case 0x8c:
+				/*
+				 * Signal that the reset sequence has begun.
+				 *
+				 * This opcode signals that the software reset sequence has begun.
+				 * Ordinarily, no actual operations are performed by the opcode.
+				 * However it allows for possible software work arounds by devinit
+				 * engines in software agents other than the VBIOS, such as the resman,
+				 * FCODE, and EFI driver. This opcode is designed to be included in
+				 * the devinit script immediately after the NV_PMC_ENABLE register
+				 * has be written to put most engines into a reset state.
+				 *
+				 * Present on [core6,)
+				 */
 				printcmd (soff, 1);
-				printf ("UNK8C\n");
+				printf ("RESET_BEGUN\n");
 				soff++;
 				break;
 			case 0x8d:


### PR DESCRIPTION
This series adds support to nouveau for two opcodes seen on VBIOSes prior to the locked-down PMU taking over responsibility for executing devinit scripts.