### PR TITLE
nvbios: Document / parse Volta & Turing devinit opcodes

### DIFF
--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -832,6 +832,11 @@ void printscript (uint16_t soff) {
 				printf ("I2C_WORD_CONDITION\tI2C[0x%02x][0x%02x][0x%02x] & 0x%04x == 0x%04x\n", bios->data[soff+1], bios->data[soff+2], bios->data[soff+3], le16(soff+4), le16(soff+6));
 				soff += 8;
 				break;
+			case 0xb6: // Turing: Related to I2C_IF and I2C_IF_LONG and INIT_I2C_WORD_CONDITION
+				printcmd (soff, 6);
+				printf ("UNKB6\tI2C[0x%02x][0x%02x][0x%02x] & 0x%02x == 0x%02x\n", bios->data[soff+1], bios->data[soff+2], bios->data[soff+3], bios->data[soff+4], bios->data[soff+5]);
+				soff += 6;
+				break;
 			default:
 				printcmd (soff, 1);
 				printf ("???\n");

--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -804,6 +804,13 @@ void printscript (uint16_t soff) {
 				printf ("TSOSC\n");
 				soff++;
 				break;
+			case 0xb1:
+				printcmd (soff, 3);
+				printf ("POLL_NV_COND\t0x%02x 0x%02x\n", bios->data[soff+1], bios->data[soff+2]);
+				if (bios->data[soff+1] > maxcond)
+					maxcond = bios->data[soff+1];
+				soff += 3;
+				break;
 			default:
 				printcmd (soff, 1);
 				printf ("???\n");

--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -811,6 +811,11 @@ void printscript (uint16_t soff) {
 					maxcond = bios->data[soff+1];
 				soff += 3;
 				break;
+			case 0xb2: // Volta: TO CONFIRM
+				printcmd (soff, 22);
+				printf ("UNKB2\n");
+				soff += 22;
+				break;
 			default:
 				printcmd (soff, 1);
 				printf ("???\n");

--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -827,6 +827,11 @@ void printscript (uint16_t soff) {
 					soff += 3;
 				}
 				break;
+			case 0xb4:
+				printcmd (soff, 8);
+				printf ("I2C_WORD_CONDITION\tI2C[0x%02x][0x%02x][0x%02x] & 0x%04x == 0x%04x\n", bios->data[soff+1], bios->data[soff+2], bios->data[soff+3], le16(soff+4), le16(soff+6));
+				soff += 8;
+				break;
 			default:
 				printcmd (soff, 1);
 				printf ("???\n");

--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -816,6 +816,17 @@ void printscript (uint16_t soff) {
 				printf ("UNKB2\n");
 				soff += 22;
 				break;
+			case 0xb3:
+				printcmd (soff, 4);
+				printf ("ZM_ALTERNATING16_I2CREG\tI2C[0x%02x][0x%02x]\n", bios->data[soff+1], bios->data[soff+2]);
+				cnt = bios->data[soff+3];
+				soff += 4;
+				while (cnt--) {
+					printcmd (soff, 3);
+					printf ("\t[0x%02x] = 0x%04x\n", bios->data[soff], le16(soff+1));
+					soff += 3;
+				}
+				break;
 			default:
 				printcmd (soff, 1);
 				printf ("???\n");

--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -799,6 +799,11 @@ void printscript (uint16_t soff) {
 				printcmd (soff, 0);
 				printf ("\t}\n");
 				break;
+			case 0xb0:
+				printcmd (soff, 1);
+				printf ("TSOSC\n");
+				soff++;
+				break;
 			default:
 				printcmd (soff, 1);
 				printf ("???\n");


### PR DESCRIPTION
Post PMU taking over responsibility for interpreting devinit scripts, these are helpful to debug VBIOSes. 

However, nouveau currently has no need to interpret these directly nor is a method currently known to modify devinit scripts in VBIOSes in a way that allows modified versions to be loaded by the PMU.

This series adds all devinit opcodes verified as present within a corpus of Volta and Turing GPUs.