### PR TITLE
nvbios/perf: Fix overwritten parameter c1 in VOLTAGE MAP TABLE v10

### DIFF
--- a/nvbios/nvbios.c
+++ b/nvbios/nvbios.c
@@ -1706,7 +1706,7 @@ int main(int argc, char **argv) {
 				max = le32(start+0x4);
 				c0  = le32(start+0x8);
 				c1  = le32(start+0xc);
-				c1  = le32(start+0x10);
+				c2  = le32(start+0x10);
 				break;
 			case 0x20:
 				mode = bios->data[start];


### PR DESCRIPTION
During the last refactoring of this function to parse the VOLTAGE MAP TABLE, the parameter c2 was never recorded. Instead the previous c1 value was overwritten.

Noticed whilst reviewing this code for upcoming changes. Verified against the nouveau kernel code.

An example before/after fixed output from an NVCF vbios:
```diff
$ openssl sha256 nvcf/mwk/vbios.rom
SHA256(nvcf/mwk/vbios.rom)= e020fa7e2fdca5e84ee22a2c57deb85489bf77aa04d2cd8ef4bd8b6406d52fe0

$ diff -u /tmp/v1.txt /tmp/v2.txt 
--- /tmp/v1.txt	2019-06-04 23:09:57.234220569 +1000
+++ /tmp/v2.txt	2019-06-04 23:10:50.864455474 +1000
@@ -8,7 +8,7 @@
 -- ID = 1, voltage_min = 950000, voltage_max = 950000, volt = 950000 [µV]
 0x000066c5: f0 7e 0e 00 f0 7e 0e 00 60 f5 90 00 00 00 00 00 00 00 00 00
 
--- ID = 2, voltage_min = 1012500, voltage_max = 1125000, volt = 3857476 + (80268 * S) / 10 [µV]
+-- ID = 2, voltage_min = 1012500, voltage_max = 1125000, volt = 3857476 + (-30362 * S) / 10 + (80268 * S²) / 100000 [µV]
 0x000066d9: 14 73 0f 00 88 2a 11 00 b1 9a 4c 02 66 89 ff ff 8c 39 01 00
 
 -- ID = 3, voltage_min = 0, voltage_max = 0, volt = 0 [µV]
```



Fixes: 4a71faf6 ("nvbios: parse the formular of the voltage map table")