### PR TITLE
nva: Compile on musl

### DIFF
--- a/nva/nva.c
+++ b/nva/nva.c
@@ -35,6 +35,7 @@
 #include <dirent.h>
 #include <string.h>
 #include <fcntl.h>
+#include <limits.h>
 
 #define PLATFORM_DEVICES_DIR "/sys/bus/platform/devices"
 


### PR DESCRIPTION
In glibc, limits.h is included in nva.c though stdlib.h. However, on musl, that is not the case. Due to this, compilation on musl fails due to PATH_MAX not being found. This commit adds the relevant include declaration.