### PR TITLE
Fix compilation with gcc10 which defaults to -fcommon

### DIFF
--- a/demmt/mmt_bin2dedma.c
+++ b/demmt/mmt_bin2dedma.c
@@ -37,6 +37,10 @@
 static const int interpret_args_as_text = 0;
 static const int dump_addr1_as_diff = 0;
 
+static struct mmt_txt_nvidia_state
+{
+} mmt_txt_nv_state;
+
 void txt_memread(struct mmt_read *w, void *state)
 {
 	unsigned char *data = &w->data[0];

--- a/demmt/mmt_bin2dedma.h
+++ b/demmt/mmt_bin2dedma.h
@@ -19,10 +19,6 @@ void txt_msg(uint8_t *data, unsigned int len, void *state);
 void txt_write_syscall(struct mmt_write_syscall *o, void *state);
 void txt_dup(struct mmt_dup_syscall *o, void *state);
 
-struct mmt_txt_nvidia_state
-{
-} mmt_txt_nv_state;
-
 extern const struct mmt_nvidia_decode_funcs txt_nvidia_funcs;
 extern const struct mmt_nvidia_decode_funcs txt_nvidia_funcs_empty;
 void dump_args(struct mmt_memory_dump *args, int argc);

--- a/include/var.h
+++ b/include/var.h
@@ -93,13 +93,13 @@ struct vardata {
 	int validated;
 };
 
-enum {
+enum vardata_symtype {
 	VARDATA_ST_FEATURE,
 	VARDATA_ST_VARIANT,
 	VARDATA_ST_VARSET,
 	VARDATA_ST_MODE,
 	VARDATA_ST_MODESET,
-} vardata_symtype;
+};
 
 struct vardata *vardata_new(const char *name);
 void vardata_del(struct vardata *data);


### PR DESCRIPTION
GCC 10 defaults to -fcommon, so it is no longer allowed to put non
extern variable declarations in .h files otherwise we get linker
errors about conflicting symbols in the .o files.

This commit fixes these linking errors.