### PR TITLE
Add TU104 based GeForce RTX 2060

### DIFF
--- a/docs/hw/pciid.rst
+++ b/docs/hw/pciid.rst
@@ -1644,6 +1644,7 @@ device id  product
 ========== ========================================================
 ``0x1e82`` TU104 [GeForce RTX 2080]
 ``0x1e87`` TU104 [GeForce RTX 2080]
+``0x1e89`` TU104 [GeForce RTX 2060]
 ``0x1e90`` TU104 [GeForce RTX 2080 Mobile]
 ``0x1eb0`` TU104 [Quadro RTX 5000]
 ``0x1eb1`` TU104 [Quadro RTX 4000]


### PR DESCRIPTION
At some point nVidia released a TU104 based RTX 2060. https://en.wikipedia.org/wiki/GeForce_20_series#Chipset_table

Update pciid.rst to reflect that.