### PR TITLE
Revert "Fix compilation with gcc10 which defaults to -fcommon"

### DIFF
--- a/demmt/mmt_bin2dedma.c
+++ b/demmt/mmt_bin2dedma.c
@@ -37,10 +37,6 @@
 static const int interpret_args_as_text = 0;
 static const int dump_addr1_as_diff = 0;
 
-static struct mmt_txt_nvidia_state
-{
-} mmt_txt_nv_state;
-
 void txt_memread(struct mmt_read *w, void *state)
 {
 	unsigned char *data = &w->data[0];


### PR DESCRIPTION
Reverts envytools/envytools#201

As said in [this comment](https://github.com/envytools/envytools/pull/201#issuecomment-623635859) - similar fix has already landed and github CI failed to detect it.
Pardon for the breakage.
