### PR TITLE
nvbios: nv34 (openfirmware) fixes

### DIFF
--- a/nvbios/bios.c
+++ b/nvbios/bios.c
@@ -167,7 +167,8 @@ static unsigned int find_string(struct envy_bios *bios, const uint8_t *str, int 
 	return 0;
 }
 
-static void parse_bmp_nv03(struct envy_bios *bios) {
+static void parse_bmp_nv03(struct envy_bios *bios)
+{
 	int err = 0;
 	err |= bios_u8(bios, bios->bmp_offset + 5, &bios->bmp_ver_major);
 	err |= bios_u8(bios, bios->bmp_offset + 6, &bios->bmp_ver_minor);
@@ -184,7 +185,8 @@ static void parse_bmp_nv03(struct envy_bios *bios) {
 	/* XXX: add block for init script */
 }
 
-int envy_bios_parse (struct envy_bios *bios) {
+int envy_bios_parse(struct envy_bios *bios)
+{
 	uint16_t vendor, device;
 	parse_pcir(bios);
 	if (bios->partsnum) {

--- a/nvbios/dcb.c
+++ b/nvbios/dcb.c
@@ -329,7 +329,7 @@ int envy_bios_parse_rdcb (struct envy_bios *bios) {
 	if (err)
 		return -EFAULT;
 	envy_bios_block(bios, dcb->offset - dcb->rdcb_len, dcb->rdcb_len, "RDCB", -1);
-	if (dcb->rdcb_version < 0x16) {
+	if (dcb->rdcb_version < 0x15) { // no table for a nv34 0x15 device
 		bios->odcb_offset = dcb->offset - dcb->rdcb_len - 0x80;
 		envy_bios_block(bios, bios->odcb_offset, 0x80, "ODCB", -1);
 	}

--- a/nvbios/dcb.c
+++ b/nvbios/dcb.c
@@ -333,7 +333,8 @@ int envy_bios_parse_rdcb (struct envy_bios *bios) {
 		bios->odcb_offset = dcb->offset - dcb->rdcb_len - 0x80;
 		envy_bios_block(bios, bios->odcb_offset, 0x80, "ODCB", -1);
 	}
-	dcb->rdcb_valid = 1;
+	// Doesn't seem like a valid table
+	dcb->rdcb_valid = dcb->rdcb_version != 0x15;
 	return 0;
 }
 

--- a/nvbios/dcb.c
+++ b/nvbios/dcb.c
@@ -73,7 +73,7 @@ int envy_bios_parse_dcb (struct envy_bios *bios) {
 		case 0x20:
 		case 0x21:
 			wanthlen = dcb->hlen = 8;
-			dcb->entriesnum = 16;
+			dcb->entriesnum = 16; // dummy placeholder
 			wantrlen = dcb->rlen = 8;
 			err |= bios_u8(bios, dcb->offset+1, &defs);
 			err |= bios_u16(bios, dcb->offset+2, &bios->i2c.offset);
@@ -120,6 +120,7 @@ int envy_bios_parse_dcb (struct envy_bios *bios) {
 			return -EINVAL;
 	}
 	envy_bios_block(bios, dcb->offset, dcb->hlen + dcb->rlen * dcb->entriesnum, "DCB", -1);
+	// what does this ^^ do again? do we need correct entriesnum?
 	if (dcb->version >= 0x14 && dcb->version < 0x30) {
 		uint8_t dev_rec[7];
 		int j;
@@ -151,10 +152,30 @@ int envy_bios_parse_dcb (struct envy_bios *bios) {
 	if (dcb->rlen > wantrlen) {
 		ENVY_BIOS_WARN("DCB table record longer than expected [%d > %d]\n", dcb->rlen, wantrlen);
 	}
+	int i;
+
+	for (i = 0; i < dcb->entriesnum; i++) {
+		uint16_t offset = dcb->offset + dcb->hlen + dcb->rlen * i;
+		uint8_t type;
+
+		if (dcb->version >= 0x30) // Educated guess, confirmed on 0x22
+			break;
+
+		err |= bios_u8(bios, offset, &type);
+		if (err)
+			return -EFAULT;
+
+		if (type == 0xff) { // only [0] or ff ff ff ff ff ff ff ff
+			dcb->entriesnum = i + 1;
+			// let's print the terminating entry
+			break;
+		}
+	}
+
 	dcb->entries = calloc(dcb->entriesnum, sizeof *dcb->entries);
 	if (!dcb->entries)
 		return -ENOMEM;
-	int i;
+
 	for (i = 0; i < dcb->entriesnum; i++) {
 		struct envy_bios_dcb_entry *entry = &dcb->entries[i];
 		entry->offset = dcb->offset + dcb->hlen + dcb->rlen * i;


### PR DESCRIPTION
Here are a few tweaks, based on the openfirmare bios in this thread [1]. Note reply with vbios may be stuck in moderation queue.

There are two types of issues:
 - using hardcoded number of dcb/i2c entries, instead of stopping when a terminator is found
 - printing odcb/rdcb (what are those again?) tables, which do not exist
 
@imirkin from a quick look at drm/nouveau - it's already honouring the above

[1] https://lists.freedesktop.org/archives/nouveau/2020-May/035991.html