### PR TITLE
Add NVC0_2D_SET_DST_COLOR_RENDER_TO_ZETA_SURFACE mthd

### DIFF
--- a/rnndb/graph/g80_2d.xml
+++ b/rnndb/graph/g80_2d.xml
@@ -119,7 +119,8 @@ xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
 			<value value="2" name="BITMAP_1X64"/>
 			<value value="3" name="COLOR"/>
 		</reg32>
-		<reg32 offset="0x02b8" name="UNK02B8" length="9" variants="GF100_2D-"/>
+		<reg32 offset="0x02b8" name="SET_DST_COLOR_RENDER_TO_ZETA_SURFACE" type="boolean" variants="GF100_2D-"/>
+		<reg32 offset="0x02bc" name="UNK02BC" length="8" variants="GF100_2D-"/>
 		<reg32 offset="0x02dc" name="UNK2DC" variants="GF100_2D-">
 			<doc>0-2</doc>
 		</reg32>


### PR DESCRIPTION
Update rnndb with documented Nvidia cl902d.h (NVC0_2D) mthd `NVC0_2D_SET_DST_COLOR_RENDER_TO_ZETA_SURFACE`.

This is sourced from:
- https://github.com/NVIDIA/open-gpu-doc/blob/master/classes/twod/cl902d.h

And was already manually added by bskeggs to the otherwise autogenerated
header file in mesa:
- https://gitlab.freedesktop.org/mesa/mesa/-/commit/af3c2f3cfd81186b0041e5297db5225fc788b04e