### PR TITLE
vstream: fix h264 ref reorder list print error

### DIFF
--- a/vstream/h264_print.c
+++ b/vstream/h264_print.c
@@ -334,7 +334,7 @@ void h264_print_ref_pic_list_modification(struct h264_ref_pic_list_modification 
 	for (i = 0; list->list[i].op != 3; i++) {
 		int op = list->list[i].op;
 		printf("\tmodification_of_pic_nums_idc = %d [%s]\n", op, opnames[op]);
-		printf("\t%s = %d\n", argnames[op], list->list[i].op);
+		printf("\t%s = %d\n", argnames[op], list->list[i].param);
 	}
 	printf("\tmodification_of_pic_nums_idc = 3 [END]\n");
 }


### PR DESCRIPTION
Found a tiny, tiny bug while using the parser as reference
H.264 printer prints the modification_of_pic_nums_idc opcode twice in place of the pic_num delta it operates on